### PR TITLE
Add order photo preview

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -78,7 +78,28 @@ class COM1CBridge:
                 return False
         except Exception as e:
             log(f"❌ Ошибка при формировании PDF: {e}")
-            return False     
+            return False
+
+    def print_order_preview_pdf_with_photo(self, number: str) -> bool:
+        obj = self._find_document_by_number("ЗаказВПроизводство", number)
+        if not obj:
+            log(f"[Печать] Заказ №{number} не найден")
+            return False
+        try:
+            form = obj.GetForm("ФормаДокумента")
+            temp_dir = tempfile.gettempdir()
+            pdf_path = os.path.join(temp_dir, f"Заказ_{number}_photo.pdf")
+            form.PrintFormToFile("Заказ в производство с фото", pdf_path)
+            if os.path.exists(pdf_path):
+                log(f"📄 PDF сформирован: {pdf_path}")
+                os.startfile(pdf_path)
+                return True
+            else:
+                log("❌ Не удалось сохранить PDF")
+                return False
+        except Exception as e:
+            log(f"❌ Ошибка при формировании PDF: {e}")
+            return False
 
     def _find_document_by_number(self, doc_name: str, number: str):
         doc = getattr(self.documents, doc_name, None)

--- a/pages/orders_page.py
+++ b/pages/orders_page.py
@@ -117,13 +117,16 @@ class OrdersPage(QWidget):
         btns.addWidget(self.btn_update)
         for label, func in [
             ("🖨 Печать", self._print_selected_order),
+            ("🖨 С фото", self._print_selected_order_with_photo),
             ("+ строка", self._add_row),
             ("− строка", self._remove_row),
             ("Новый заказ", self._new_order),
             ("📋 Копировать строку", self._copy_row),
             ("💾 Записать", self._post_close)
         ]:
-            btn = QPushButton(label); btn.clicked.connect(func); btns.addWidget(btn)
+            btn = QPushButton(label)
+            btn.clicked.connect(func)
+            btns.addWidget(btn)
         v.addLayout(btns)
         self.tabs.addTab(self.frm_new, "Новый заказ")
 
@@ -161,7 +164,21 @@ class OrdersPage(QWidget):
         number = self.tbl_orders.item(selected, 1).text().strip().replace("⚪", "")
         success = bridge.print_order_preview_pdf(number)
         if not success:
-            QMessageBox.critical(self, "Ошибка", f"Не удалось сформировать предпросмотр для заказа №{number}")   
+            QMessageBox.critical(self, "Ошибка", f"Не удалось сформировать предпросмотр для заказа №{number}")
+
+    def _print_selected_order_with_photo(self):
+        selected = self.tbl_orders.currentRow()
+        if selected < 0:
+            QMessageBox.warning(self, "Ошибка", "Выберите заказ для печати")
+            return
+        number = self.tbl_orders.item(selected, 1).text().strip().replace("⚪", "")
+        success = bridge.print_order_preview_pdf_with_photo(number)
+        if not success:
+            QMessageBox.critical(
+                self,
+                "Ошибка",
+                f"Не удалось сформировать предпросмотр с фото для заказа №{number}"
+            )
 
     def _add_row(self, copy_from: int = None):
         r = self.tbl.rowCount()


### PR DESCRIPTION
## Summary
- implement PDF preview of order with photo
- hook up '🖨 С фото' button to new preview method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684492cc627c832a883814532957ae71