### PR TITLE
Fix wax page import

### DIFF
--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QTreeWidget, QTreeWidgetItem,
     QHeaderView, QPushButton, QMessageBox
 )
-from production_docs import WAX_JOBS_POOL, ORDERS_POOL, METHOD_LABEL
+from logic.production_docs import WAX_JOBS_POOL, ORDERS_POOL, METHOD_LABEL
 
 CSS_TREE = """
 QTreeWidget{


### PR DESCRIPTION
## Summary
- ensure wax page refers to single production_docs module

## Testing
- `python -m py_compile pages/wax_page.py`

------
https://chatgpt.com/codex/tasks/task_e_684559b07ec0832ab72bf600e9fb14a0