### PR TITLE
Fix order status text

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -471,7 +471,7 @@ class COM1CBridge:
             for row in doc.Товары:
                 rows.append({
                     "nomenclature": safe_str(row.Номенклатура),
-                    "size": row.Размер,
+                    "size": safe_str(row.Размер),
                     "qty": row.Количество,
                     "w": row.Вес,
                     "variant": safe_str(row.ВариантИзготовления),
@@ -484,7 +484,7 @@ class COM1CBridge:
                 "contragent": safe_str(doc.Контрагент),
                 "contract": safe_str(doc.ДоговорКонтрагента),
                 "comment": safe_str(doc.Комментарий),
-                "prod_status": safe_str(doc.ВидСтатусПродукции),
+                "prod_status": self.to_string(doc.ВидСтатусПродукции),
                 "posted": doc.Проведен,
                 "deleted": doc.ПометкаУдаления,
                 "qty": sum([r["qty"] for r in rows]),

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QTreeWidget, QTreeWidgetItem,
     QHeaderView, QPushButton, QMessageBox
 )
-from production_docs import WAX_JOBS_POOL, ORDERS_POOL, METHOD_LABEL
+from logic.production_docs import WAX_JOBS_POOL, ORDERS_POOL, METHOD_LABEL
 
 CSS_TREE = """
 QTreeWidget{


### PR DESCRIPTION
## Summary
- use `to_string` for order production status so COM enums get readable text

## Testing
- `python -m py_compile pages/wax_page.py core/com_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_684559b07ec0832ab72bf600e9fb14a0