### PR TITLE
Fix wax jobs listing

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -586,6 +586,12 @@ class COM1CBridge:
         
     def list_tasks(self, limit: int = 100) -> list[dict]:
         """Список заданий на производство"""
+        from core.config_parser import has_document
+
+        if not has_document("ЗаданиеНаПроизводство"):
+            log("[CONFIG] Документ 'ЗаданиеНаПроизводство' не найден")
+            return []
+
         result = []
         catalog = self.connection.Documents.ЗаданиеНаПроизводство
         selection = catalog.Select()
@@ -603,6 +609,11 @@ class COM1CBridge:
         return result    
         
     def list_wax_jobs(self) -> list[dict]:
+        from core.config_parser import has_document
+
+        if not has_document("НарядВосковыеИзделия"):
+            log("[CONFIG] Документ 'НарядВосковыеИзделия' не найден")
+            return []
         try:
             doc = self.connection.Documents["НарядВосковыеИзделия"]
             selection = doc.Select()
@@ -610,16 +621,17 @@ class COM1CBridge:
             while selection.Next():
                 obj = selection.GetObject()
                 jobs.append({
-                    "Ref": str(obj.Ref),
-                    "Номер": str(obj.Number),
-                    "Дата": str(obj.Date),
-                    "Сотрудник": str(obj.Сотрудник) if hasattr(obj, "Сотрудник") else "",
-                    "Комментарий": str(obj.Комментарий) if hasattr(obj, "Комментарий") else "",
+                    "ref": str(obj.Ref),
+                    "num": str(obj.Number),
+                    "date": str(obj.Date),
+                    "employee": safe_str(getattr(obj, "Сотрудник", "")),
+                    "comment": safe_str(getattr(obj, "Комментарий", "")),
+                    "status": "Проведен" if getattr(obj, "Проведен", False) else ""
                 })
             return jobs
         except Exception as e:
             print("[LOG] ❌ Ошибка получения нарядов:", e)
-            return []   
+            return []
 
 
     # ------------------------------------------------------------------

--- a/core/config_parser.py
+++ b/core/config_parser.py
@@ -6,6 +6,25 @@ from pathlib import Path
 CONFIG_XML = Path("data/Configuration.xml")
 DUMP_XML = Path("data/ConfigDumpInfo.xml")
 
+# ─────────────────────── Список документов из Configuration.xml ──────────────
+def extract_document_names() -> list[str]:
+    """Возвращает все имена документов из Configuration.xml."""
+    if not CONFIG_XML.exists():
+        return []
+
+    tree = ET.parse(CONFIG_XML)
+    root = tree.getroot()
+
+    names = []
+    for elem in root.iter():
+        if elem.tag.endswith("Document") and not list(elem) and elem.text:
+            names.append(elem.text)
+    return names
+
+def has_document(name: str) -> bool:
+    """Проверяет наличие документа с указанным именем."""
+    return name in extract_document_names()
+
 # ─────────────────────── Реальная загрузка значений справочников ───────────────────────
 def get_catalog_items(name: str) -> list[str]:
     """Чтение значений конкретного справочника из ConfigDumpInfo.xml"""


### PR DESCRIPTION
## Summary
- check for document names in `Configuration.xml`
- add helper functions to parse document names from configuration
- guard listing of tasks and wax jobs if documents not present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845b160089c832a9fb6e47912bfde6d