### PR TITLE
Fix COM task creation and event duplication

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -791,7 +791,7 @@ class COM1CBridge:
         if doc_manager is None:
             raise Exception("Документ 'ЗаданиеНаПроизводство' не найден")
         doc = doc_manager.CreateDocument()
-        doc.Основание = order_ref
+        doc.ДокументОснование = self.connection.GetObject(order_ref)
         doc.Дата = self.connection.CurrentDate()
 
         for row in rows:
@@ -929,7 +929,6 @@ class COM1CBridge:
                 r.Вес = row.get("weight", 0)
                 r.Проба = str(row.get("hallmark", ""))
                 r.ЦветМеталла = self.get_ref("ЦветаМеталлов", row.get("color"))
-                r.АртикулГП = row.get("article")
 
             doc.Write()
             doc.Провести()
@@ -970,7 +969,6 @@ class COM1CBridge:
                 r.Проба = row.Проба
                 r.ЦветМеталла = row.ЦветМеталла
                 r.Вес = row.Вес
-                r.АртикулГП = row.АртикулГП
 
             doc.Write()
             doc.Провести()
@@ -1014,7 +1012,6 @@ class COM1CBridge:
                     r.Проба = row.Проба
                     r.ЦветМеталла = row.ЦветМеталла
                     r.Вес = row.Вес
-                    r.АртикулГП = row.АртикулГП
 
                 doc.Write()
                 doc.Провести()

--- a/main.py
+++ b/main.py
@@ -159,5 +159,3 @@ if __name__ == "__main__":
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
     app = QApplication(sys.argv); app.setStyle("Fusion")
     win = Main(); win.show(); sys.exit(app.exec_())
-    
-    from core.com_bridge import COM1CBridge

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -46,14 +46,12 @@ class WaxPage(QWidget):
         super().__init__()
         self._ui()
         self.refresh()
-        
+
     def refresh(self):
         self._fill_jobs_tree()
         self._fill_parties_tree()
         self._fill_tasks_tree()
-        self._fill_wax_jobs_tree()    
-        self.tree_acts.itemDoubleClicked.connect(self._on_wax_job_double_click)
-        self.tree_tasks.itemDoubleClicked.connect(self._on_task_double_click)
+        self._fill_wax_jobs_tree()
 
     # ------------------------------------------------------------------
     def _ui(self):
@@ -134,6 +132,10 @@ class WaxPage(QWidget):
         self.tree_acts.header().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.tree_acts.setStyleSheet(CSS_TREE)
         t3.addWidget(self.tree_acts, 1)
+
+        # подключения сигналов
+        self.tree_tasks.itemDoubleClicked.connect(self._on_task_double_click)
+        self.tree_acts.itemDoubleClicked.connect(self._on_wax_job_double_click)
 
         self.tabs.addTab(tab3, "Наряды из 1С")
         
@@ -252,16 +254,13 @@ class WaxPage(QWidget):
 
         for o in ORDERS_POOL:
             order = o.get("order", {})
-        7f9ne8-codex/исправить-ошибку-keyerror-в-wax_page.py
+
             order_ref = order.get("Ref")
             if not order_ref:
-                QMessageBox.warning(self, "Ошибка", "У заказа нет ссылки Ref для создания задания")
-       
-            order_ref = bridge.get_doc_ref("ЗаказВПроизводство", order.get("num", ""))
-            if not order_ref:
-                QMessageBox.warning(self, "Ошибка", f"Не найден заказ {order.get('num')} в базе 1С")
-        main
-                continue
+                order_ref = bridge.get_doc_ref("ЗаказВПроизводство", order.get("num", ""))
+                if not order_ref:
+                    QMessageBox.warning(self, "Ошибка", f"Не найден заказ {order.get('num')} в базе 1С")
+                    continue
 
             method_to_items = defaultdict(list)
 


### PR DESCRIPTION
## Summary
- clean up stray artifacts from wax page
- move double-click signal wiring to UI init
- ensure task references are resolved before creation
- remove invalid `АртикулГП` assignments
- use `ДокументОснование` when creating production tasks

## Testing
- `python -m py_compile main.py pages/wax_page.py core/com_bridge.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'win32com')*

------
https://chatgpt.com/codex/tasks/task_e_6845edb6d1b4832ab2d60e08535f54cb