### PR TITLE
Fix COM task creation and event duplication

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -791,7 +791,7 @@ class COM1CBridge:
         if doc_manager is None:
             raise Exception("Документ 'ЗаданиеНаПроизводство' не найден")
         doc = doc_manager.CreateDocument()
-        doc.Основание = order_ref
+        doc.ДокументОснование = self.connection.GetObject(order_ref)
         doc.Дата = self.connection.CurrentDate()
 
         for row in rows:
@@ -929,7 +929,6 @@ class COM1CBridge:
                 r.Вес = row.get("weight", 0)
                 r.Проба = str(row.get("hallmark", ""))
                 r.ЦветМеталла = self.get_ref("ЦветаМеталлов", row.get("color"))
-                r.АртикулГП = row.get("article")
 
             doc.Write()
             doc.Провести()
@@ -970,7 +969,6 @@ class COM1CBridge:
                 r.Проба = row.Проба
                 r.ЦветМеталла = row.ЦветМеталла
                 r.Вес = row.Вес
-                r.АртикулГП = row.АртикулГП
 
             doc.Write()
             doc.Провести()
@@ -1014,7 +1012,6 @@ class COM1CBridge:
                     r.Проба = row.Проба
                     r.ЦветМеталла = row.ЦветМеталла
                     r.Вес = row.Вес
-                    r.АртикулГП = row.АртикулГП
 
                 doc.Write()
                 doc.Провести()

--- a/main.py
+++ b/main.py
@@ -159,5 +159,3 @@ if __name__ == "__main__":
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
     app = QApplication(sys.argv); app.setStyle("Fusion")
     win = Main(); win.show(); sys.exit(app.exec_())
-    
-    from core.com_bridge import COM1CBridge

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -46,14 +46,12 @@ class WaxPage(QWidget):
         super().__init__()
         self._ui()
         self.refresh()
-        
+
     def refresh(self):
         self._fill_jobs_tree()
         self._fill_parties_tree()
         self._fill_tasks_tree()
-        self._fill_wax_jobs_tree()    
-        self.tree_acts.itemDoubleClicked.connect(self._on_wax_job_double_click)
-        self.tree_tasks.itemDoubleClicked.connect(self._on_task_double_click)
+        self._fill_wax_jobs_tree()
 
     # ------------------------------------------------------------------
     def _ui(self):
@@ -108,7 +106,7 @@ class WaxPage(QWidget):
         t1.addWidget(self.tree_part, 1)
 
         self.tabs.addTab(tab1, "Наряды")
-        
+
         # ----- Tab 2: Задания -----
         tab2 = QWidget(); t2 = QVBoxLayout(tab2)
         lbl2 = QLabel("Задания на производство")
@@ -135,8 +133,12 @@ class WaxPage(QWidget):
         self.tree_acts.setStyleSheet(CSS_TREE)
         t3.addWidget(self.tree_acts, 1)
 
+        # подключения сигналов
+        self.tree_tasks.itemDoubleClicked.connect(self._on_task_double_click)
+        self.tree_acts.itemDoubleClicked.connect(self._on_wax_job_double_click)
+
         self.tabs.addTab(tab3, "Наряды из 1С")
-        
+
     def _show_wax_job_detail(self, item):
         from PyQt5.QtWidgets import QDialog, QTableWidget, QTableWidgetItem, QVBoxLayout
         num = item.text(0)
@@ -162,8 +164,8 @@ class WaxPage(QWidget):
         tbl.resizeColumnsToContents()
         layout.addWidget(tbl)
         dlg.setLayout(layout)
-        dlg.exec_()    
-        
+        dlg.exec_()
+
     def _on_task_double_click(self, item, column):
         num = item.text(0).strip()
         if not num:
@@ -189,8 +191,8 @@ class WaxPage(QWidget):
             ])
         layout.addWidget(tree)
         dlg.resize(700, 400)
-        dlg.exec_()    
-        
+        dlg.exec_()
+
     def _on_wax_job_double_click(self, item, column):
         num = item.text(0).strip()
         if not num:
@@ -216,8 +218,8 @@ class WaxPage(QWidget):
             ])
         layout.addWidget(tree)
         dlg.resize(700, 400)
-        dlg.exec_()    
-        
+        dlg.exec_()
+
     def _fill_tasks_tree(self):
         self.tree_tasks.clear()
         for t in bridge.list_tasks():
@@ -242,8 +244,8 @@ class WaxPage(QWidget):
                 t.get("tech_op", ""),
                 t.get("status", ""),
                 t.get("based_on", "")
-            ])    
-        
+            ])
+
 
     def _create_task(self):
         if not ORDERS_POOL:
@@ -252,16 +254,13 @@ class WaxPage(QWidget):
 
         for o in ORDERS_POOL:
             order = o.get("order", {})
-        7f9ne8-codex/исправить-ошибку-keyerror-в-wax_page.py
+
             order_ref = order.get("Ref")
             if not order_ref:
-                QMessageBox.warning(self, "Ошибка", "У заказа нет ссылки Ref для создания задания")
-       
-            order_ref = bridge.get_doc_ref("ЗаказВПроизводство", order.get("num", ""))
-            if not order_ref:
-                QMessageBox.warning(self, "Ошибка", f"Не найден заказ {order.get('num')} в базе 1С")
-        main
-                continue
+                order_ref = bridge.get_doc_ref("ЗаказВПроизводство", order.get("num", ""))
+                if not order_ref:
+                    QMessageBox.warning(self, "Ошибка", f"Не найден заказ {order.get('num')} в базе 1С")
+                    continue
 
             method_to_items = defaultdict(list)
 
@@ -288,7 +287,7 @@ class WaxPage(QWidget):
                     QMessageBox.information(self, "Готово", f"Задание №{result['Номер']} создано")
                 except Exception as e:
                     QMessageBox.critical(self, "Ошибка создания задания", str(e))
-        
+
         self.refresh()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clean up stray artifacts from wax page
- move double-click signal wiring to UI init
- ensure task references are resolved before creation
- remove invalid `АртикулГП` assignments
- use `ДокументОснование` when creating production tasks
- fix indentation issues

## Testing
- `python -m py_compile main.py pages/wax_page.py core/com_bridge.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'win32com')*

------
https://chatgpt.com/codex/tasks/task_e_6845edb6d1b4832ab2d60e08535f54cb