### PR TITLE
Fix reference handling for task creation

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -723,7 +723,11 @@ class COM1CBridge:
 
         try:
             doc = doc_manager.CreateDocument()
-            doc.ДокументОснование = self.connection.GetObject(order_ref)
+            # order_ref may already be a COM object; only call GetObject for strings
+            if isinstance(order_ref, str):
+                doc.ДокументОснование = self.connection.GetObject(order_ref)
+            else:
+                doc.ДокументОснование = order_ref
             doc.Дата = self.connection.CurrentDate()
 
             # 👉 Автоматически заполняем заголовок:


### PR DESCRIPTION
## Summary
- handle both strings and COM objects when setting ДокументОснование in `create_production_task`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684670cfba44832abcb80c47ad4d3d7d