### PR TITLE
Fix wax job creation from selected task

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -935,7 +935,17 @@ class COM1CBridge:
             return self.connection.GetObject(ref)
         except Exception as e:
             log(f"[get_object_from_ref] ❌ Ошибка получения объекта по ссылке: {e}")
-            return None        
+            return None
+
+    def get_object_from_ref(self, ref):
+        try:
+            if not ref:
+                log("[get_object_from_ref] ❌ Пустая ссылка")
+                return None
+            return self.connection.GetObject(ref)
+        except Exception as e:
+            log(f"[get_object_from_ref] ❌ Ошибка получения объекта по ссылке: {e}")
+            return None
 
     # ------------------------------------------------------------------
     def create_multiple_wax_jobs_from_task(self, task_ref, method_to_employee: dict) -> list[str]:

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -269,31 +269,17 @@ class WaxPage(QWidget):
         self._fill_tasks_tree()    
 
     def _on_task_double_click(self, item, column):
-        num = item.text(0).strip()
+        num = item.text(1).strip() if item.columnCount() > 1 else item.text(0).strip()
         if not num:
             return
 
-        lines = bridge.get_task_lines(num)
-        if not lines:
-            QMessageBox.information(self, "Нет данных", f"В задании {num} нет строк")
-            return
-
-        from PyQt5.QtWidgets import QDialog, QVBoxLayout, QTreeWidget, QTreeWidgetItem
-
-        dlg = QDialog(self)
-        dlg.setWindowTitle(f"Продукция по заданию {num}")
-        layout = QVBoxLayout(dlg)
-
-        tree = QTreeWidget()
-        tree.setHeaderLabels(["Номенклатура", "Размер", "Проба", "Цвет", "Кол-во", "Вес"])
-        for row in lines:
-            QTreeWidgetItem(tree, [
-                row["nomen"], str(row["size"]), str(row["sample"]),
-                str(row["color"]), str(row["qty"]), str(row["weight"])
-            ])
-        layout.addWidget(tree)
-        dlg.resize(700, 400)
-        dlg.exec_()
+        task_obj = bridge._find_task_by_number(num)
+        if task_obj:
+            self.last_created_task_ref = task_obj
+            self.tabs.setCurrentIndex(0)
+            log(f"[UI] Выбрано задание №{num}, переходим к созданию нарядов.")
+        else:
+            log(f"[UI] ❌ Задание №{num} не найдено")
 
     def _on_wax_job_double_click(self, item, column):
         num = item.text(0).strip()
@@ -432,7 +418,8 @@ class WaxPage(QWidget):
             try:
                 result = bridge.create_production_task(order_ref, rows)
                 docs["sync_task_num"] = result.get("Номер")  # ✅ запоминаем
-                self.last_created_task_ref = bridge._get_object_from_ref(result.get("Ref"))
+                ref = result.get("Ref")
+                self.last_created_task_ref = bridge.get_object_from_ref(ref) if ref else None
                 log(f"✅ Создано задание №{result.get('Номер', '?')}")
             except Exception as e:
                 log(f"❌ Ошибка создания задания: {e}")
@@ -451,7 +438,7 @@ class WaxPage(QWidget):
             return
 
         if not self.last_created_task_ref:
-            QMessageBox.warning(self, "Ошибка", "Нет последнего созданного задания")
+            QMessageBox.warning(self, "Ошибка", "Нет выбранного задания для создания нарядов.")
             return
 
         result = bridge.create_multiple_wax_jobs_from_task(


### PR DESCRIPTION
## Summary
- add safe `get_object_from_ref` to COM bridge
- enable selecting a task to create wax jobs from
- store selected task reference
- warn when no task is chosen

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846d720b27c832aa006d72eed8c8b92