### PR TITLE
Fix organization and warehouse in production tasks

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -739,6 +739,11 @@ class COM1CBridge:
             doc.КонечнаяДатаЗадания = datetime.now() + timedelta(days=1)
             doc.ДокументОснование = base_doc
 
+            # копируем организацию и склад из заказа, чтобы наряды могли
+            # корректно создаваться по заданию
+            doc.Организация = getattr(base_doc, "Организация", None)
+            doc.Склад = getattr(base_doc, "Склад", None)
+
             # Шапка
             doc.ПроизводственныйУчасток = self.get_ref("ПроизводственныеУчастки", "задание на производство")
             doc.ТехОперация = self.get_ref("ТехОперации", "работа с восковыми изделиями")
@@ -977,8 +982,12 @@ class COM1CBridge:
             try:
                 job = self.documents.НарядВосковыеИзделия.CreateDocument()
                 job.Дата = datetime.now()
-                job.Организация = task.Организация
-                job.Склад = task.Склад
+                org = getattr(task, "Организация", None)
+                if org:
+                    job.Организация = org
+                wh = getattr(task, "Склад", None)
+                if wh:
+                    job.Склад = wh
                 job.ПроизводственныйУчасток = task.ПроизводственныйУчасток
                 job.ЗаданиеНаПроизводство = task
                 job.ТехОперация = self.get_ref("ТехОперации", "3D" if method == "3D печать" else "Пресс-форма")


### PR DESCRIPTION
## Summary
- ensure production tasks copy organization and warehouse from order
- handle missing organization when creating wax jobs

## Testing
- `python -m py_compile core/com_bridge.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846e7b815c0832a86b07855e94add85