### PR TITLE
Fix wax job creation without order data

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -739,6 +739,15 @@ class COM1CBridge:
             doc.КонечнаяДатаЗадания = datetime.now() + timedelta(days=1)
             doc.ДокументОснование = base_doc
 
+            # копируем организацию и склад из заказа, чтобы наряды могли
+            # корректно создаваться по заданию
+            org = getattr(base_doc, "Организация", None)
+            if org:
+                doc.Организация = org
+            wh = getattr(base_doc, "Склад", None)
+            if wh:
+                doc.Склад = wh
+
             # Шапка
             doc.ПроизводственныйУчасток = self.get_ref("ПроизводственныеУчастки", "задание на производство")
             doc.ТехОперация = self.get_ref("ТехОперации", "работа с восковыми изделиями")
@@ -977,8 +986,12 @@ class COM1CBridge:
             try:
                 job = self.documents.НарядВосковыеИзделия.CreateDocument()
                 job.Дата = datetime.now()
-                job.Организация = task.Организация
-                job.Склад = task.Склад
+                org = getattr(task, "Организация", None)
+                if org:
+                    job.Организация = org
+                wh = getattr(task, "Склад", None)
+                if wh:
+                    job.Склад = wh
                 job.ПроизводственныйУчасток = task.ПроизводственныйУчасток
                 job.ЗаданиеНаПроизводство = task
                 job.ТехОперация = self.get_ref("ТехОперации", "3D" if method == "3D печать" else "Пресс-форма")

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -427,9 +427,9 @@ class WaxPage(QWidget):
 
     # ------------------------------------------------------------------
     def _create_wax_jobs(self):
-        if not ORDERS_POOL:
-            QMessageBox.warning(self, "Нет данных", "Нет заказов для создания нарядов")
-            return
+        # Для создания наряда достаточно выбранного задания.
+        # Проверка ORDERS_POOL мешала создавать наряды для уже существующих
+        # заданий, поэтому её убрали.
 
         master_3d = self.combo_3d_master.currentText().strip()
         master_resin = self.combo_resin_master.currentText().strip()


### PR DESCRIPTION
## Summary
- avoid assigning None to organization and warehouse when creating tasks
- remove ORDERS_POOL check so wax jobs can be created from any selected task

## Testing
- `python -m py_compile core/com_bridge.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846e7b815c0832a86b07855e94add85