### PR TITLE
Fix wax job creation by using russian field name

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -962,8 +962,10 @@ class COM1CBridge:
         """Создаёт по заданию два наряда: для 3D и для резины."""
         result = []
         
+        log(f"[create_jobs] type(task_ref) = {type(task_ref)}")
         try:
-            organization = task_ref.Organization
+            organization = getattr(task_ref, "Организация")
+            log(f"[create_jobs] Организация задания: {safe_str(organization)}")
         except Exception as e:
             log(f"❌ Ошибка получения Организации из задания: {e}")
             return []


### PR DESCRIPTION
## Summary
- fix organization property retrieval when creating wax jobs
- log task object type and organization for easier debugging

## Testing
- `python -m py_compile core/com_bridge.py`
- `python -m py_compile pages/wax_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f5cf11f0832a9da8b3e67eaa1291