### PR TITLE
Fix missing doc ref method and log task info

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -562,6 +562,23 @@ class COM1CBridge:
         except Exception as e:
             log(f"[get_doc_object_by_number] ❌ Ошибка: {e}")
         return None
+
+    def get_doc_ref(self, doc_name: str, number: str):
+        """Возвращает ссылку на документ по номеру."""
+        docs = getattr(self.connection.Documents, doc_name, None)
+        if docs is None:
+            log(f"[get_doc_ref] Документ '{doc_name}' не найден")
+            return None
+
+        selection = docs.Select()
+        while selection.Next():
+            doc = selection.GetObject()
+            if str(doc.Number).strip() == str(number).strip():
+                log(f"[get_doc_ref] ✅ Найден документ {doc_name} №{number}")
+                return doc.Ref
+
+        log(f"[get_doc_ref] ❌ Документ {doc_name} №{number} не найден")
+        return None
     # ------------------------------------------------------------------
     def list_orders(self):
         result = []
@@ -962,8 +979,18 @@ class COM1CBridge:
         """Создаёт по заданию два наряда: для 3D и для резины."""
         result = []
         
+        log(f"[create_jobs] type(task_ref) = {type(task_ref)}")
+        log(
+            f"[create_jobs] hasattr 'Организация': {hasattr(task_ref, 'Организация')} "
+            f"hasattr 'Organization': {hasattr(task_ref, 'Organization')}"
+        )
         try:
-            organization = task_ref.Organization
+            organization = getattr(
+                task_ref,
+                "Организация",
+                getattr(task_ref, "Organization", None),
+            )
+            log(f"[create_jobs] Организация задания: {safe_str(organization)}")
         except Exception as e:
             log(f"❌ Ошибка получения Организации из задания: {e}")
             return []

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -279,7 +279,10 @@ class WaxPage(QWidget):
             return
 
         self.last_created_task_ref = obj
-        log(f"[DEBUG] last_created_task_ref = {obj}")
+        log(
+            f"[DEBUG] last_created_task_ref type={type(obj)}, has Org? "
+            f"{hasattr(obj, 'Организация')}"
+        )
         self.refresh()
         self.tabs.setCurrentIndex(0)
         log(f"[UI] Выбрано задание №{num}, переходим к созданию нарядов.")


### PR DESCRIPTION
## Summary
- restore `get_doc_ref` helper on the bridge
- log attribute availability when creating wax jobs
- log type info when task is selected

## Testing
- `python -m py_compile core/com_bridge.py pages/wax_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6846f5cf11f0832a9da8b3e67eaa1291