### PR TITLE
Fix order link when creating tasks

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -761,19 +761,28 @@ class COM1CBridge:
             doc.Дата = datetime.now()
             doc.КонечнаяДатаЗадания = datetime.now() + timedelta(days=1)
             doc.ДокументОснование = base_doc
+            if hasattr(doc, "Заказ"):
+                try:
+                    doc.Заказ = base_doc
+                except Exception as e:
+                    log(f"[create_production_task] ⚠ Не удалось установить заказ: {e}")
 
             # копируем организацию и склад из заказа, чтобы наряды могли
             # корректно создаваться по заданию
 
             org = getattr(base_doc, "Организация", None)
-            if org:
-                doc.Организация = org
-            wh = getattr(base_doc, "Склад", None)
-            if wh:
-                doc.Склад = wh
+            if org and hasattr(doc, "Организация"):
+                try:
+                    doc.Организация = org
+                except Exception as e:
+                    log(f"[create_production_task] ⚠ Не удалось установить организацию: {e}")
 
-            doc.Организация = getattr(base_doc, "Организация", None)
-            doc.Склад = getattr(base_doc, "Склад", None)
+            wh = getattr(base_doc, "Склад", None)
+            if wh and hasattr(doc, "Склад"):
+                try:
+                    doc.Склад = wh
+                except Exception as e:
+                    log(f"[create_production_task] ⚠ Не удалось установить склад: {e}")
 
 
             # Шапка
@@ -837,7 +846,7 @@ class COM1CBridge:
             doc.Write()
             log(f"✅ Задание создано: №{doc.Номер}")
             return {
-                "Ref": str(doc.Ref),
+                "Ref": doc.Ref,
                 "Номер": str(doc.Номер),
                 "Дата": str(doc.Дата)
             }


### PR DESCRIPTION
## Summary
- set `Заказ` header field when creating production tasks
- return COM reference object so `get_object_from_ref` works

## Testing
- `python -m py_compile core/com_bridge.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684728fb31d4832aa5b0a1664a607ab1