### PR TITLE
Remove unused wax_method helper

### DIFF
--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -602,11 +602,3 @@ class WaxPage(QWidget):
                         str(d["qty"]), f"{d['weight']:.3f}"
                     ])
 
-
-
-# ----------------------------------------------------------------------
-def _wax_method(article: str) -> str:
-    art = str(article).lower()
-    if "д" in art or "d" in art:
-        return "3D печать"
-    return "Пресс-форма"


### PR DESCRIPTION
## Summary
- delete unused `_wax_method` function from `pages/wax_page.py`
- tidy trailing blank lines

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497bc27f3c832abcc69c76851cfd21