### PR TITLE
Fix missing catalog log call

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -679,7 +679,7 @@ class COM1CBridge:
         """Возвращает ссылку на первое задание по указанному методу."""
         method_ref = self.get_ref_by_description("ВариантыИзготовленияНоменклатуры", method)
         if not method_ref:
-            print_catalog_contents("ВариантыИзготовленияНоменклатуры")
+            self.log_catalog_contents("ВариантыИзготовленияНоменклатуры")
         if method_ref is None:
             log(f"[find_production_task_ref_by_method] Не найден вариант {method}")
             return None


### PR DESCRIPTION
## Summary
- use `self.log_catalog_contents` when method reference isn't found

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497bc988b0832a8c6dd7f779f23e7e