### PR TITLE
Enable selecting production order via Orders tab

### DIFF
--- a/pages/orders_page.py
+++ b/pages/orders_page.py
@@ -50,6 +50,11 @@ class OrdersPage(QWidget):
         self._load_orders()
         self._edit_mode = False
         self._current_number = ""
+        self._select_callback = None
+
+    def set_selection_callback(self, callback=None):
+        """Устанавливает внешний callback для выбора заказа."""
+        self._select_callback = callback
         
     def _update_order(self):
         if not self._edit_mode or not self._current_number:
@@ -397,6 +402,12 @@ class OrdersPage(QWidget):
         self._load_orders()
 
     def _show_order(self, row, col):
+        if self._select_callback:
+            order_number = self.tbl_orders.item(row, 1).text().strip().replace("⚪", "")
+            self._select_callback(order_number)
+            self._select_callback = None
+            return
+
         o = self._orders[row]
         
         self.comment_input.setText(o.get("comment", ""))

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -31,6 +31,18 @@ class WaxPage(QWidget):
         """Позволяет передать внешний объект страницы нарядов."""
         self.jobs_page = jobs_page
 
+    def goto_order_selection(self, callback=None):
+        """Открывает вкладку Заказы и передаёт callback выбора."""
+        from pages.orders_page import OrdersPage
+        if hasattr(self.parent(), "tabs"):
+            for i in range(self.parent().tabs.count()):
+                w = self.parent().tabs.widget(i)
+                if isinstance(w, OrdersPage):
+                    self.parent().tabs.setCurrentIndex(i)
+                    if hasattr(w, "set_selection_callback"):
+                        w.set_selection_callback(callback)
+                    break
+
     def refresh(self):
         self._fill_jobs_tree()
         self._fill_parties_tree()

--- a/widgets/production_task_form.py
+++ b/widgets/production_task_form.py
@@ -50,7 +50,7 @@ class ProductionTaskEditForm(QWidget):
 
         self.order_line = QLineEdit(); self.order_line.setReadOnly(True)
         self.btn_order = QPushButton("Выбрать")
-        self.btn_order.clicked.connect(self.load_from_order)
+        self.btn_order.clicked.connect(self.request_order_selection)
         h_order = QHBoxLayout(); h_order.addWidget(self.order_line); h_order.addWidget(self.btn_order)
 
         form.addRow("Номер", self.lbl_number)
@@ -126,20 +126,38 @@ class ProductionTaskEditForm(QWidget):
         if row >= 0:
             self.tbl.removeRow(row)
 
+    def request_order_selection(self):
+        """Запрашивает выбор заказа на внешней вкладке."""
+        parent = self.parent()
+        if hasattr(parent, "goto_order_selection"):
+            parent.goto_order_selection(callback=self.load_order_by_number)
+
     def load_from_order(self):
         orders = self.bridge.list_orders()
         nums = [o.get("num") for o in orders]
         num, ok = QInputDialog.getItem(self, "Выбор заказа", "Заказ", nums, 0, False)
         if not ok or not num:
             return
-        self.order_line.setText(num)
-        self._order_ref = self.bridge.get_doc_ref("ЗаказВПроизводство", num)
+        self.load_order_by_number(num)
+        self.lbl_status.setText("Заполнено")
+
+    def load_order_by_number(self, order_number: str):
+        """Загружается из внешнего выбора (например, из вкладки Заказы)."""
+        self.order_line.setText(order_number)
+        self._order_ref = self.bridge.get_doc_ref("ЗаказВПроизводство", order_number)
+        self._load_lines(order_number)
+
+    def _load_lines(self, num):
         lines = self.bridge.get_order_lines(num)
         self.tbl.setRowCount(0)
         for line in lines:
             self.add_row()
             r = self.tbl.rowCount() - 1
+            self.tbl.item(r, 0).setText(str(r + 1))
+            self.tbl.item(r, 1).setText(QDate.currentDate().toString("dd.MM.yyyy"))
+            self.tbl.item(r, 2).setText(QDate.currentDate().addDays(1).toString("dd.MM.yyyy"))
             self.tbl.item(r, 3).setText(line.get("article", ""))
+            self.tbl.item(r, 4).setText(self.c_center.currentText())
             self.tbl.item(r, 5).setText(line.get("name", ""))
             self.tbl.item(r, 6).setText(line.get("method", ""))
             self.tbl.item(r, 7).setText(str(line.get("size", "")))
@@ -147,8 +165,8 @@ class ProductionTaskEditForm(QWidget):
             self.tbl.item(r, 9).setText(str(line.get("weight", "")))
             self.tbl.item(r, 10).setText(line.get("assay", ""))
             self.tbl.item(r, 11).setText(line.get("color", ""))
+            self.tbl.item(r, 12).setText(line.get("insert", ""))
             self.tbl.item(r, 13).setText(num)
-        self.lbl_status.setText("Заполнено")
 
     def _collect_rows(self):
         rows = []


### PR DESCRIPTION
## Summary
- hook "Выбрать" button in production task form to switch to Orders tab
- allow Wax page to open Orders page and pass callback
- add callback support in Orders page
- fill more fields when loading order lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849df3a9830832a83f58b95dc09ed11