### PR TITLE
Добавлена аутентификация через 1С

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,8 +9,17 @@ BASE_DIR = Path(__file__).resolve().parent
 # Path to 1C database
 ONEC_PATH = os.getenv("ONEC_PATH", "C:/Users/Mor/Desktop/1C/proiz")
 
-# Global COM bridge instance
-BRIDGE = COM1CBridge(ONEC_PATH)
+# Глобальный экземпляр COM‑моста
+BRIDGE = None
+
+
+def init_bridge(user: str, password: str, base_path: str | None = None):
+    """Инициализирует подключение к 1С с указанными учётными данными."""
+    global BRIDGE
+    if base_path is None:
+        base_path = ONEC_PATH
+    BRIDGE = COM1CBridge(base_path, usr=user, pwd=password)
+    return BRIDGE
 
 # Application
 APP_NAME = "Jewelry MES (shell-only)"

--- a/logic/normalize_catalogs.py
+++ b/logic/normalize_catalogs.py
@@ -5,7 +5,7 @@
 
 
 from collections import defaultdict
-from config import BRIDGE as bridge
+import config
 
 _NORMALIZED = None
 
@@ -17,7 +17,7 @@ def load_normalized():
 
     normalized = {"Камни": [], "Вставки": [], "Изделия": []}
 
-    nomenclature = bridge.list_catalog_items("Номенклатура", 10000)
+    nomenclature = config.BRIDGE.list_catalog_items("Номенклатура", 10000)
     for item in nomenclature:
         name = item.get("Наименование", "")
         insert = item.get("Вставка", "")

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ sys.path.append(str(base_dir / "core"))
 sys.path.append(str(base_dir / "logic"))
 
 from config import (
-    BRIDGE as bridge,
     APP_NAME as APP,
     APP_VERSION as VER,
     MENU_ITEMS,
@@ -25,11 +24,13 @@ from config import (
     HEADER_CSS,
     SIDEBAR_CSS,
 )
+import config
+from widgets import LoginDialog
 from PyQt5.QtCore    import Qt
 from PyQt5.QtGui     import QFont, QCursor
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget, QLabel, QListWidget, QStackedWidget,
-    QVBoxLayout, QHBoxLayout, QToolButton
+    QVBoxLayout, QHBoxLayout, QToolButton, QDialog
 )
 
 # Страницы
@@ -101,7 +102,7 @@ class Main(QMainWindow):
             elif key == "wax":
                 page = WaxPage()
             elif key == "catalogs":
-                page = CatalogsPage(bridge)  # ← вот это обязательно!
+                page = CatalogsPage(config.BRIDGE)  # ← вот это обязательно!
             else:
                 page = StubPage(title.strip())
             self.pages.addWidget(page)
@@ -123,4 +124,13 @@ class Main(QMainWindow):
 if __name__ == "__main__":
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
     app = QApplication(sys.argv); app.setStyle("Fusion")
-    win = Main(); win.show(); sys.exit(app.exec_())
+
+    dlg = LoginDialog()
+    if dlg.exec_() != QDialog.Accepted:
+        sys.exit()
+    user, password = dlg.get_credentials()
+    config.init_bridge(user, password)
+
+    win = Main()
+    win.show()
+    sys.exit(app.exec_())

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,0 +1,3 @@
+from .login_dialog import LoginDialog
+
+__all__ = ["LoginDialog"]

--- a/widgets/login_dialog.py
+++ b/widgets/login_dialog.py
@@ -1,0 +1,29 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QLineEdit, QDialogButtonBox
+from PyQt5.QtCore import Qt
+
+
+class LoginDialog(QDialog):
+    """Простое диалоговое окно для ввода учётных данных 1С."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Вход в 1С")
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+        self.ed_user = QLineEdit(); self.ed_user.setPlaceholderText("Пользователь")
+        self.ed_pass = QLineEdit(); self.ed_pass.setEchoMode(QLineEdit.Password)
+        form.addRow("Пользователь", self.ed_user)
+        form.addRow("Пароль", self.ed_pass)
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_credentials(self):
+        return self.ed_user.text().strip(), self.ed_pass.text()


### PR DESCRIPTION
## Summary
- реализован `LoginDialog` для ввода имени пользователя и пароля
- добавлена функция `init_bridge` для подключения к 1С с указанными данными
- страницы и логика используют `config.BRIDGE` после инициализации
- при запуске GUI показывается форма логина и после успешного входа создаётся основной интерфейс

## Testing
- `python -m py_compile widgets/login_dialog.py main.py pages/orders_page.py pages/wax_page.py logic/normalize_catalogs.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aae9ff8e0832a8cb0e7cf1bab9728