### PR TITLE
Fix operation selection for production tasks

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -849,7 +849,8 @@ class COM1CBridge:
                     log(f"[create_production_task] ⚠ Не удалось установить склад: {e}")
 
             doc.ПроизводственныйУчасток = self.get_ref("ПроизводственныеУчастки", "задание на производство")
-            doc.ТехОперация = self.get_ref("ТехОперации", "работа с восковыми изделиями")
+            operation = rows[0].get("operation", "работа с восковыми изделиями")
+            doc.ТехОперация = self.get_ref("ТехОперации", operation)
             employee_name = rows[0].get("employee", "Администратор")
             doc.РабочийЦентр = self.get_ref("ФизическиеЛица", employee_name)
             doc.Ответственный = self.get_ref("Пользователи", "Администратор")
@@ -885,7 +886,7 @@ class COM1CBridge:
                     z = doc.ЗаданияНаВыполнениеТехОперации.Add()
                     z.Вес = float(row.get("weight", 0) or 0)
                     z.Заказ = base_doc_ref
-                    z.ТехОперация = self.get_ref("ТехОперации", "работа с восковыми изделиями")
+                    z.ТехОперация = self.get_ref("ТехОперации", row.get("operation", operation))
                     z.РабочийЦентр = self.get_ref("ФизическиеЛица", employee_name)
                     z.Номенклатура = self.get_ref("Номенклатура", row.get("name", ""))
                     z.ВариантИзготовления = self.get_ref("ВариантыИзготовленияНоменклатуры", row.get("method", ""))

--- a/widgets/production_task_form.py
+++ b/widgets/production_task_form.py
@@ -288,6 +288,7 @@ class ProductionTaskEditForm(QWidget):
                 "color": self._cell_text(r, 11),
                 "insert": self._cell_text(r, 12),
                 "employee": self.c_center.currentText(),
+                "operation": self.c_op.currentText(),
             })
         return rows
 


### PR DESCRIPTION
## Summary
- include selected operation when collecting rows in production task form
- pass chosen operation to 1C when creating production tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abb23df4c832ab504f08aa5c8c7b4