### PR TITLE
Add weight precision constant

### DIFF
--- a/config.py
+++ b/config.py
@@ -123,3 +123,6 @@ QTreeView::item:nth-child(odd):!selected { background:#ffffff; }
 
 # Columns for the orders table
 ORDERS_COLS = ["Артикул", "Наим.", "Вариант", "Размер", "Кол-во", "Вес, г", "Примечание"]
+
+# Число знаков после запятой при отображении веса
+WEIGHT_DECIMALS = 3

--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from .logger import logger
+import config
 
 # ---------------------------
 # Маппинг описаний в системные имена перечисления
@@ -931,7 +932,7 @@ class COM1CBridge:
                 "hallmark": hallmark,
                 "color": color,
                 "qty": data["qty"],
-                "total_w": round(data["total_w"], 3)
+                "total_w": round(data["total_w"], config.WEIGHT_DECIMALS)
             })
         return result      
             

--- a/logic/production_docs.py
+++ b/logic/production_docs.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from catalogs import NOMENCLATURE                      # метод 3d / rubber
 from core.logger import logger
+import config
 
 from .state import ORDERS_POOL, WAX_JOBS_POOL  # централизованное хранилище
 
@@ -52,7 +53,7 @@ def group_by_keys(items: list[dict], keys: tuple[str]):
             batch_barcode = code,
             **{k:v for k,v in zip(keys,key)},
             qty     = len(grp),
-            total_w = round(sum(i["weight"] for i in grp),3)
+            total_w = round(sum(i["weight"] for i in grp), config.WEIGHT_DECIMALS)
         ))
         mapping[code] = [i["item_barcode"] for i in grp]
     return batches, mapping

--- a/pages/orders_page.py
+++ b/pages/orders_page.py
@@ -212,7 +212,9 @@ class OrdersPage(QWidget):
         size.setSingleStep(0.5)     # шаг изменения
         size.setValue(16.0)
         qty = QSpinBox(); qty.setRange(1, 999); qty.setValue(1)
-        wgt = QDoubleSpinBox(); wgt.setDecimals(3); wgt.setMaximum(9999)
+        wgt = QDoubleSpinBox()
+        wgt.setDecimals(config.WEIGHT_DECIMALS)
+        wgt.setMaximum(9999)
         comment = QLineEdit()
         self.tbl.setCellWidget(r, 6, comment)
 
@@ -229,7 +231,7 @@ class OrdersPage(QWidget):
             name.setText(card.get("name", ""))
             if card.get("size"):
                 size.setValue(float(card["size"]))
-            wgt.setValue(round(card.get("w", 0) * qty.value(), 3))
+            wgt.setValue(round(card.get("w", 0) * qty.value(), config.WEIGHT_DECIMALS))
 
             # 🟡 добавляем недостающую строку
             article = art.currentText()
@@ -352,7 +354,7 @@ class OrdersPage(QWidget):
             status = "🟢" if o.get("posted") else ("❌" if o.get("deleted") else "⚪")
             vals = [
                 f"{status} {o['num']}", o["date"], o.get("prod_status", ""),
-                o.get("qty", 0), f"{o.get('weight', 0):.3f}",
+                o.get("qty", 0), f"{o.get('weight', 0):.{config.WEIGHT_DECIMALS}f}",
                 o.get("org", ""), o.get("contragent", ""), o.get("contract", ""), o.get("comment", "")
             ]
             for i, v in enumerate(vals):

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -437,7 +437,7 @@ class WaxPage(QWidget):
                 f"{method_label} ({wax_code})",
                 method_label,
                 str(total_qty),
-                f"{total_weight:.3f}",
+                f"{total_weight:.{config.WEIGHT_DECIMALS}f}",
                 j0.get("status", ""),
                 '✅' if j0.get('sync_doc_num') else ''
             ])
@@ -449,7 +449,7 @@ class WaxPage(QWidget):
                     r["articles"],
                     "",
                     str(r["qty"]),
-                    f"{r.get('weight', 0.0):.3f}",
+                    f"{r.get('weight', 0.0):.{config.WEIGHT_DECIMALS}f}",
                     "", ""
                 ])
 
@@ -464,7 +464,7 @@ class WaxPage(QWidget):
             for b in pack["docs"].get("batches", []):
                 root = QTreeWidgetItem(self.tree_part, [
                     f"Партия {b['batch_barcode']}  ({b['metal']} {b['hallmark']} {b['color']})",
-                    str(b["qty"]), f"{b['total_w']:.3f}"
+                    str(b["qty"]), f"{b['total_w']:.{config.WEIGHT_DECIMALS}f}"
                 ])
                 root.setExpanded(True)
 
@@ -479,6 +479,6 @@ class WaxPage(QWidget):
                 for (art, size), d in agg.items():
                     QTreeWidgetItem(root, [
                         f"{art}  (р-р {size})",
-                        str(d["qty"]), f"{d['weight']:.3f}"
+                        str(d["qty"]), f"{d['weight']:.{config.WEIGHT_DECIMALS}f}"
                     ])
 


### PR DESCRIPTION
## Summary
- control decimal precision for weights globally
- use `config.WEIGHT_DECIMALS` in pages and modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abe42d40c832a8abb6a0c1d91c578