### PR TITLE
Load employee logins from config dump

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from core.logger import logger  # инициализация логирования
 from core.com_bridge import COM1CBridge
+from core import config_parser
 
 # Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent
@@ -85,11 +86,27 @@ QPushButton:hover{background:#2563eb;}
 """
 
 # Список логинов сотрудников для выпадающего меню
-EMPLOYEE_LOGINS = [
-    "Администратор",
-    "Иванов",
-    "Петров",
-]
+def load_employee_logins() -> list[str]:
+    """Возвращает список логинов сотрудников."""
+    default = [
+        "Администратор",
+        "Альфа-софт",
+        "АщеуловаНВ",
+        "Давыдова Т.В.",
+        "НачинкинаЮС",
+        "Тест",
+        "ЧисловаМН",
+    ]
+
+    try:
+        users = config_parser.get_catalog_items("Пользователи")
+        return users or default
+    except Exception as exc:  # безопасность на случай проблем парсинга
+        logger.error("Не удалось загрузить логины сотрудников: %s", exc)
+        return default
+
+
+EMPLOYEE_LOGINS = load_employee_logins()
 
 # Style for tree widgets used on the wax page
 CSS_TREE = """


### PR DESCRIPTION
## Summary
- add a helper `load_employee_logins()` reading catalog dump
- use this helper to populate the `EMPLOYEE_LOGINS` constant
- refresh login dialog dropdown using the helper

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ac75d2488832aa0d5b150d9498dab