### PR TITLE
Load employee logins from 1C via COM

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from core.logger import logger  # инициализация логирования
 from core.com_bridge import COM1CBridge
+from core import config_parser
 
 # Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent
@@ -85,11 +86,27 @@ QPushButton:hover{background:#2563eb;}
 """
 
 # Список логинов сотрудников для выпадающего меню
-EMPLOYEE_LOGINS = [
-    "Администратор",
-    "Иванов",
-    "Петров",
-]
+def load_employee_logins() -> list[str]:
+    """Возвращает список логинов сотрудников через COM с резервным чтением."""
+    fallback = ["Администратор"]
+
+    try:
+        bridge = BRIDGE or COM1CBridge(ONEC_PATH, usr="Администратор", pwd="")
+        items = bridge.list_catalog_items("Пользователи", 1000)
+        logins = [it.get("Description", "") for it in items if it.get("Description")]
+        if logins:
+            return logins
+    except Exception as exc:
+        logger.error("Не удалось получить логины через COM: %s", exc)
+
+    try:
+        users = config_parser.get_catalog_items("Пользователи")
+        return users or fallback
+    except Exception as exc:
+        logger.error("Не удалось загрузить логины из XML: %s", exc)
+        return fallback
+
+
 
 # Style for tree widgets used on the wax page
 CSS_TREE = """

--- a/widgets/login_dialog.py
+++ b/widgets/login_dialog.py
@@ -24,7 +24,7 @@ class LoginDialog(QDialog):
 
         form = QFormLayout()
         self.c_user = QComboBox(); self.c_user.setEditable(True)
-        self.c_user.addItems(config.EMPLOYEE_LOGINS)
+        self.c_user.addItems(config.load_employee_logins())
         self.ed_pass = QLineEdit(); self.ed_pass.setEchoMode(QLineEdit.Password)
         form.addRow("Пользователь", self.c_user)
         form.addRow("Пароль", self.ed_pass)


### PR DESCRIPTION
## Summary
- fetch login names using COM bridge instead of XML dump
- fallback to parsing `ConfigDumpInfo.xml` when COM fails
- populate login dialog dropdown with fresh list via helper

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ac75d2488832aa0d5b150d9498dab