### PR TITLE
Update wax job fields

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -730,27 +730,27 @@ class COM1CBridge:
         while docs.Next():
             obj = docs.GetObject()
 
-            rows = getattr(obj, "Товары", [])
+            rows = getattr(obj, "Выдано", [])
             weight = 0.0
             qty = 0
             for r in rows:
                 weight += getattr(r, "Вес", 0)
                 qty += getattr(r, "Количество", 0)
 
-
             result.append({
                 "Номер": str(obj.Номер),
-                "Метод": safe_str(obj.ТехОперация.Description),
                 "Дата": obj.Дата.strftime("%d.%m.%Y"),
-                "Сотрудник": safe_str(obj.Сотрудник.Description),
-
-                "Вес": weight,
+                "Закрыт": "✅" if getattr(obj, "Проведен", False) else "—",
+                "Сотрудник": safe_str(obj.Сотрудник),
+                "ТехОперация": safe_str(obj.ТехОперация),
+                "Комментарий": safe_str(obj.Комментарий),
+                "Склад": safe_str(obj.Склад),
+                "ПроизводственныйУчасток": safe_str(obj.ПроизводственныйУчасток),
+                "Организация": safe_str(obj.Организация),
+                "Задание": safe_str(getattr(obj, "ЗаданиеНаПроизводство", "")) or "—",
+                "Ответственный": safe_str(obj.Ответственный),
+                "Вес": round(weight, 2),
                 "Кол-во": qty,
-
-                "Вес": sum([getattr(r, "Вес", 0) for r in obj.Товары]),
-                "Кол-во": sum([getattr(r, "Количество", 0) for r in obj.Товары]),
-
-                "Проведен": obj.Проведен,
             })
         return result
         

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -151,7 +151,17 @@ class WaxPage(QWidget):
 
         self.tree_jobs = QTreeWidget()
         self.tree_jobs.setHeaderLabels([
-            "Наряд", "Метод", "Кол-во", "Вес", "Статус", "Док."
+            "Номер",
+            "Дата",
+            "Закрыт",
+            "Сотрудник",
+            "Тех. операция",
+            "Комментарий",
+            "Склад",
+            "Участок",
+            "Организация",
+            "Задание",
+            "Ответственный",
         ])
         self.tree_jobs.header().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.tree_jobs.setStyleSheet(CSS_TREE)
@@ -503,11 +513,17 @@ class WaxPage(QWidget):
         jobs = config.BRIDGE.list_wax_jobs()
         for job in jobs:
             item = QTreeWidgetItem([
-                f"{job['Номер']} ({job['Метод']})",
-                job["Метод"],
-                str(job["Кол-во"]),
-                f"{job['Вес']:.2f} г",
-                "✅ Проведен" if job["Проведен"] else "⏳ Черновик",
+                job["Номер"],
+                job["Дата"],
+                job["Закрыт"],
+                job["Сотрудник"],
+                job["ТехОперация"],
+                job["Комментарий"],
+                job["Склад"],
+                job["ПроизводственныйУчасток"],
+                job["Организация"],
+                job["Задание"],
+                job["Ответственный"],
             ])
             self.tree_jobs.addTopLevelItem(item)
 


### PR DESCRIPTION
## Summary
- extend `list_wax_jobs` to return complete info
- display full wax job data in GUI

## Testing
- `python -m py_compile core/com_bridge.py pages/wax_page.py`


------
https://chatgpt.com/codex/tasks/task_e_684adbd912a8832aa3501ed4811fc135