### PR TITLE
Добавлен вывод номера и даты задания при создании наряда

### DIFF
--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -155,6 +155,9 @@ class WaxPage(QWidget):
         self.btn_select_task.clicked.connect(self.select_task_for_wax_jobs)
         j_new.addWidget(self.btn_select_task, alignment=Qt.AlignLeft)
 
+        self.lbl_task_info = QLabel("Задание не выбрано")
+        j_new.addWidget(self.lbl_task_info, alignment=Qt.AlignLeft)
+
         self.tbl_task_lines = QTableWidget(0, 7)
         self.tbl_task_lines.setHorizontalHeaderLabels([
             "Номенклатура", "Артикул", "Размер", "Проба", "Цвет",
@@ -397,6 +400,14 @@ class WaxPage(QWidget):
 
         self.last_created_task_ref = task_obj
         self._fill_jobs_table_from_task(task_obj)
+
+        if hasattr(self, "lbl_task_info"):
+            try:
+                d = str(task_obj.Дата)[:10]
+            except Exception:
+                d = ""
+            self.lbl_task_info.setText(f"Задание №{task_obj.Номер} от {d}")
+
         log(f"[UI] ✅ Загружены данные задания №{task_obj.Номер}")
 
     def _fill_jobs_table_from_task(self, task_obj):


### PR DESCRIPTION
## Summary
- show selected task number and date on wax job creation tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aebc7fa44832aae9fe9a55e36e3fc