### PR TITLE
Fix tech operation lookup for jobs

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1140,7 +1140,11 @@ class COM1CBridge:
                     job.Склад = wh
                 job.ПроизводственныйУчасток = task.ПроизводственныйУчасток
                 job.ЗаданиеНаПроизводство = task
-                job.ТехОперация = self.get_ref("ТехОперации", "3D" if method == "3D печать" else "Пресс-форма")
+                operation_name = "3D печать" if method == "3D печать" else "Пресс-форма"
+                operation_ref = self.get_ref("ТехОперации", operation_name)
+                if not operation_ref:
+                    raise ValueError(f"Операция '{operation_name}' не найдена в справочнике 'ТехОперации'")
+                job.ТехОперация = operation_ref
 
                 master_name = method_to_employee.get(method)
                 job.Сотрудник = self.get_ref("ФизическиеЛица", master_name)
@@ -1208,7 +1212,11 @@ class COM1CBridge:
                     job.Склад = wh
                 job.ПроизводственныйУчасток = task.ПроизводственныйУчасток
                 job.ЗаданиеНаПроизводство = task
-                job.ТехОперация = self.get_ref("ТехОперации", "3D" if method == "3D печать" else "Пресс-форма")
+                operation_name = "3D печать" if method == "3D печать" else "Пресс-форма"
+                operation_ref = self.get_ref("ТехОперации", operation_name)
+                if not operation_ref:
+                    raise ValueError(f"Операция '{operation_name}' не найдена в справочнике 'ТехОперации'")
+                job.ТехОперация = operation_ref
                 master_name = mapping.get(method)
                 job.Сотрудник = self.get_ref("ФизическиеЛица", master_name)
                 job.Комментарий = f"Создан автоматически для {method}"


### PR DESCRIPTION
## Summary
- ensure wax job creation uses full tech operation names
- guard against missing tech operation refs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b427ffdac832abeaa7fec51e9fa96