### PR TITLE
Исправить имя табличной части при создании наряда

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1132,8 +1132,8 @@ class COM1CBridge:
             try:
                 job_ref = self.documents.НарядВосковыеИзделия.CreateDocument()
                 job = job_ref.GetObject() if hasattr(job_ref, "GetObject") else job_ref
-                if not hasattr(job, "Товары"):
-                    log("[create_job] ❌ Объект наряда не содержит табличной части 'Товары'")
+                if not hasattr(job, "Изделия"):
+                    log("[create_job] ❌ Объект наряда не содержит табличной части 'Изделия'")
                     continue
                 job.Дата = datetime.now()
 
@@ -1155,7 +1155,7 @@ class COM1CBridge:
                 job.Комментарий = f"Создан автоматически для {method}"
 
                 for r in rows:
-                    row = job.Товары.Add()
+                    row = job.Изделия.Add()
                     row.Номенклатура = r.Номенклатура
                     row.Количество = r.Количество
                     row.Размер = r.Размер
@@ -1210,8 +1210,8 @@ class COM1CBridge:
             try:
                 job_ref = self.documents.НарядВосковыеИзделия.CreateDocument()
                 job = job_ref.GetObject() if hasattr(job_ref, "GetObject") else job_ref
-                if not hasattr(job, "Товары"):
-                    log("[create_wax_jobs_from_task] ❌ Объект наряда не содержит табличной части 'Товары'")
+                if not hasattr(job, "Изделия"):
+                    log("[create_wax_jobs_from_task] ❌ Объект наряда не содержит табличной части 'Изделия'")
                     continue
                 job.Дата = datetime.now()
                 if organization:
@@ -1229,7 +1229,7 @@ class COM1CBridge:
                 job.Сотрудник = self.get_ref("ФизическиеЛица", master_name)
                 job.Комментарий = f"Создан автоматически для {method}"
                 for r in rows:
-                    row = job.Товары.Add()
+                    row = job.Изделия.Add()
                     row.Номенклатура = r.Номенклатура
                     row.Количество = r.Количество
                     row.Размер = r.Размер


### PR DESCRIPTION
## Summary
- use table part `Изделия` instead of nonexistent `Товары` when creating wax jobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4c9cd9d0832aacf0a58a1db88313