### PR TITLE
Add wax job attributes debug

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1214,6 +1214,7 @@ class COM1CBridge:
                 job_ref = self.documents.НарядВосковыеИзделия.CreateDocument()
                 job = job_ref.GetObject() if hasattr(job_ref, "GetObject") else job_ref
 
+                log(f"[DEBUG] Список атрибутов объекта наряда ({method}): {dir(job)}")
 
                 if not hasattr(job, "Изделия"):
                     log("[create_wax_jobs_from_task] ❌ Объект наряда не содержит табличной части 'Изделия'")


### PR DESCRIPTION
## Summary
- log available attributes of wax job objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b51c424d4832aa9a176d8124e731e