### PR TITLE
Обновление выбора склада

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1118,7 +1118,7 @@ class COM1CBridge:
             return None
     # ------------------------------------------------------------------
 
-    def create_wax_jobs_from_task(self, task_ref, master_3d: str, master_form: str) -> list[str]:
+    def create_wax_jobs_from_task(self, task_ref, master_3d: str, master_form: str, warehouse: str | None = None) -> list[str]:
         """Создаёт два наряда из одного задания по артикулу."""
         mapping = {"3D печать": master_3d, "Пресс-форма": master_form}
         result: list[str] = []
@@ -1161,6 +1161,8 @@ class COM1CBridge:
                 )
 
         section = getattr(task, "ПроизводственныйУчасток", None)
+        if warehouse:
+            wh = self.get_ref_by_description("Склады", warehouse) or wh
 
         rows_by_method = {"3D печать": [], "Пресс-форма": []}
         for row in task.Продукция:

--- a/pages/orders_page.py
+++ b/pages/orders_page.py
@@ -45,7 +45,6 @@ class OrdersPage(QWidget):
         self.organizations = config.BRIDGE.list_catalog_items("Организации")
         self.counterparties = config.BRIDGE.list_catalog_items("Контрагенты")
         self.contracts = config.BRIDGE.list_catalog_items("ДоговорыКонтрагентов")
-        self.warehouses = config.BRIDGE.list_catalog_items("Склады")
         self.production_statuses = config.BRIDGE.PRODUCTION_STATUSES
         self._ui()
         self._load_orders()
@@ -70,7 +69,6 @@ class OrdersPage(QWidget):
             "Организация": self.c_org.currentText(),
             "Контрагент": self.c_contr.currentText(),
             "ДоговорКонтрагента": self.c_ctr.currentText(),
-            "Склад": self.c_wh.currentText(),
             "Ответственный": "Администратор",
             "Комментарий": self.comment_input.text().strip(),
             "Дата": pywintypes.Time(self.d_date.date().toPyDate()),
@@ -121,13 +119,12 @@ class OrdersPage(QWidget):
         self.c_org = QComboBox(); self.c_org.addItems([x["Description"] for x in self.organizations])
         self.c_contr = QComboBox(); self.c_contr.addItems([x["Description"] for x in self.counterparties])
         self.c_ctr = QComboBox(); self.c_ctr.addItems([x["Description"] for x in self.contracts])
-        self.c_wh = QComboBox(); self.c_wh.addItems([x["Description"] for x in self.warehouses])
         self.status_combo = QComboBox(); self.status_combo.addItems(self.production_statuses)
 
         for label, widget in [
             ("Номер", self.ed_num), ("Дата", self.d_date),
             ("Организация", self.c_org), ("Контрагент", self.c_contr),
-            ("Договор", self.c_ctr), ("Склад", self.c_wh),
+            ("Договор", self.c_ctr),
             ("Вид продукции", self.status_combo)
         ]:
             form.addRow(label, widget)
@@ -285,7 +282,6 @@ class OrdersPage(QWidget):
             "Организация": self.c_org.currentText(),
             "Контрагент": self.c_contr.currentText(),
             "ДоговорКонтрагента": self.c_ctr.currentText(),
-            "Склад": self.c_wh.currentText(),
             "Ответственный": "Администратор",
             "Комментарий": self.comment_input.text().strip(),
             "Дата": pywintypes.Time(self.d_date.date().toPyDate()),

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -27,6 +27,7 @@ class WaxPage(QWidget):
         self.last_created_task_ref = None
         self.jobs_page = None
         self._task_select_callback = None
+        self.warehouses = config.BRIDGE.list_catalog_items("Склады")
         self._ui()
         self.refresh()
 
@@ -147,8 +148,11 @@ class WaxPage(QWidget):
         self.combo_3d_master.addItems(config.EMPLOYEES)
         self.combo_form_master = QComboBox(); self.combo_form_master.setEditable(True)
         self.combo_form_master.addItems(config.EMPLOYEES)
+        self.combo_warehouse = QComboBox(); self.combo_warehouse.setEditable(True)
+        self.combo_warehouse.addItems([x["Description"] for x in self.warehouses])
         form.addRow("3D печать", self.combo_3d_master)
         form.addRow("Пресс-форма", self.combo_form_master)
+        form.addRow("Склад", self.combo_warehouse)
         j_new.addLayout(form)
 
         self.btn_select_task = QPushButton("Выбрать задание")
@@ -579,9 +583,13 @@ class WaxPage(QWidget):
 
         master_3d = self.combo_3d_master.currentText().strip()
         master_resin = self.combo_form_master.currentText().strip()
+        warehouse = self.combo_warehouse.currentText().strip()
 
         if not master_3d or not master_resin:
             QMessageBox.warning(self, "Ошибка", "Выберите мастеров для обоих методов.")
+            return
+        if not warehouse:
+            QMessageBox.warning(self, "Ошибка", "Выберите склад.")
             return
 
 
@@ -595,6 +603,7 @@ class WaxPage(QWidget):
             self.last_created_task_ref,
             master_3d,
             master_resin,
+            warehouse,
         )
 
         if result:
@@ -617,11 +626,13 @@ class WaxPage(QWidget):
         if not ok or not task_num:
 
             return
+        warehouse = self.combo_warehouse.currentText().strip()
         try:
             count = config.BRIDGE.create_wax_jobs_from_task(
                 task_num,
                 self.combo_3d_master.currentText().strip(),
                 self.combo_form_master.currentText().strip(),
+                warehouse,
             )
             QMessageBox.information(self, "Готово", f"Создано {len(count)} нарядов")
             self.refresh()


### PR DESCRIPTION
## Summary
- убрать поле "Склад" из создания заказа
- добавить выбор склада при создании нарядов
- передавать выбранный склад в `create_wax_jobs_from_task`

## Testing
- `python -m py_compile core/com_bridge.py pages/orders_page.py pages/wax_page.py`

------
https://chatgpt.com/codex/tasks/task_e_684d4c2fe47c832a93a88cf7fd79d531