### PR TITLE
Fix wax job creation normative type

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -316,7 +316,15 @@ class COM1CBridge:
         if description is None:
             return None
 
-        desc = str(description).strip().lower()
+        desc = str(description).strip()
+        # Попытка прямого доступа по имени атрибута
+        try:
+            if hasattr(enum, desc):
+                return getattr(enum, desc)
+        except Exception:
+            pass
+
+        low_desc = desc.lower()
         try:
             for attr in dir(enum):
                 if attr.startswith("_"):
@@ -336,7 +344,7 @@ class COM1CBridge:
                 except Exception:
                     pres = str(val)
 
-                if pres.strip().lower() == desc or attr.lower() == desc:
+                if pres.strip().lower() == low_desc or attr.lower() == low_desc:
                     return val
         except Exception as e:
             log(f"[Enum] Ошибка поиска {description} в {enum_name}: {e}")
@@ -1116,6 +1124,17 @@ class COM1CBridge:
         except Exception as e:
             log(f"[get_object_from_ref] ❌ Ошибка получения объекта по ссылке: {e}")
             return None
+
+    def get_object_property(self, obj, prop_name: str):
+        """Возвращает значение свойства 1С-объекта."""
+        try:
+            target = obj
+            if hasattr(target, "GetObject"):
+                target = target.GetObject()
+            return getattr(target, prop_name, None)
+        except Exception as e:
+            log(f"[get_object_property] Ошибка получения {prop_name}: {e}")
+            return None
     # ------------------------------------------------------------------
 
     def create_wax_jobs_from_task(self, task_ref, master_3d: str, master_form: str, warehouse: str | None = None) -> list[str]:
@@ -1202,11 +1221,6 @@ class COM1CBridge:
                 job.Сотрудник = self.get_ref("ФизическиеЛица", mapping.get(method, ""))
                 job.Комментарий = f"Создан автоматически для {method}"
 
-                # Получаем элемент перечисления "Номенклатура" из списка видов нормативов
-                enum_norm = self.get_enum_by_description(
-                    "ВидыНормативовНоменклатуры", "Номенклатура"
-                )
-
                 # Заполнение табличной части вручную
                 for r in rows:
                     row = job.ТоварыВыдано.Add()
@@ -1219,8 +1233,19 @@ class COM1CBridge:
                         row.ХарактеристикаВставок = r.ХарактеристикаВставок
                     if hasattr(r, "Вес"):
                         row.Вес = r.Вес
-                    if enum_norm:
-                        row.ВидНорматива = enum_norm
+
+                # ---- Автоматическая подстановка вида норматива
+                for row in job.ТоварыВыдано:
+                    nomenclature = getattr(row, "Номенклатура", None)
+                    if nomenclature is not None:
+                        type_enum = self.get_object_property(nomenclature, "ТипНоменклатуры")
+                        type_name = safe_str(type_enum)
+                        enum = self.get_enum_by_description(
+                            "ВидыНормативовНоменклатуры",
+                            "Номенклатура" if type_name == "Продукция" else "Комплектующее",
+                        )
+                        if enum:
+                            row.ВидНорматива = enum
 
                 job.Write()
                 result.append(str(job.Номер))


### PR DESCRIPTION
## Summary
- better match enumeration values in COM bridge
- auto-set norm type in wax job creation using safe string name

## Testing
- `pytest -q` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684d5aa7087c832abaf2b2908b71bfde