### PR TITLE
Refactor orders and wax logic

### DIFF
--- a/core/orders_bridge.py
+++ b/core/orders_bridge.py
@@ -56,3 +56,272 @@ class OrdersBridge:
             return f"{prefix}-{next_num:06d}"
         except Exception:
             return "00ЮП-000001"
+
+    # -------------------------------------------------------------
+    # Методы работы с документом "ЗаказВПроизводство"
+    # -------------------------------------------------------------
+
+    def undo_posting(self, number: str, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[UndoPosting] Документ №{number} не найден")
+            return False
+        try:
+            obj.UndoPosting()
+            obj.Write()
+            log(f"✔ Проведение снято для заказа №{number}")
+            return True
+        except Exception as e:
+            log(f"❌ UndoPosting error: {e}")
+            return False
+
+    def delete_order_by_number(self, number: str, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[Удаление] Заказ №{number} не найден")
+            return False
+        try:
+            if getattr(obj, "Проведен", False):
+                log("⚠ Документ проведён, снимаем проведение...")
+                self.undo_posting(number)
+            obj.Delete()
+            log("🗑 Документ удалён полностью")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при удалении: {e}")
+            return False
+
+    def post_order(self, number: str, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[Проведение] Заказ №{number} не найден")
+            return False
+        try:
+            obj.Проведен = True
+            obj.Write()
+            if getattr(obj, "Проведен", False):
+                log(f"[Проведение] Заказ №{number} успешно проведён через флаг Проведен")
+                return True
+            log(f"[Проведение] Не удалось провести заказ №{number}")
+            return False
+        except Exception as e:
+            log(f"[Проведение] Ошибка при установке Проведен: {e}")
+            return False
+
+    def mark_order_for_deletion(self, number: str, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[Пометка] Документ №{number} не найден")
+            return False
+        try:
+            if getattr(obj, "Проведен", False):
+                log("⚠ Документ проведён. Снимаем проведение перед пометкой")
+                obj.UndoPosting()
+                obj.Write()
+            obj.DeletionMark = VARIANT(VT_BOOL, True)
+            obj.Write()
+            if getattr(obj, "DeletionMark", False):
+                log(f"🗑 Документ №{number} помечен на удаление")
+                return True
+            log("❌ Не удалось установить пометку на удаление")
+            return False
+        except Exception as e:
+            log(f"❌ Ошибка при установке пометки: {e}")
+            return False
+
+    def unmark_order_deletion(self, number: str, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[Снятие пометки] Документ №{number} не найден")
+            return False
+        try:
+            obj.DeletionMark = VARIANT(VT_BOOL, False)
+            obj.Write()
+            if not getattr(obj, "DeletionMark", True):
+                log(f"✅ Пометка на удаление снята с документа №{number}")
+                return True
+            log("❌ Не удалось снять пометку")
+            return False
+        except Exception as e:
+            log(f"❌ Ошибка при снятии пометки: {e}")
+            return False
+
+    def update_order(self, number: str, fields: dict, items: list, date: str | None = None) -> bool:
+        obj = self.bridge._find_document_by_number("ЗаказВПроизводство", number, date)
+        if not obj:
+            log(f"[Обновление] Заказ №{number} не найден")
+            return False
+
+        for k, v in fields.items():
+            try:
+                if k == "ВидСтатусПродукции":
+                    ref = self.bridge.get_ref("ВидыСтатусыПродукции", v)
+                    if ref:
+                        setattr(obj, k, ref)
+                    continue
+                if k in ["Организация", "Контрагент", "ДоговорКонтрагента", "Ответственный", "Склад"]:
+                    ref = self.bridge.get_ref(k + "ы" if not k.endswith("т") else k + "а", v)
+                    if ref:
+                        setattr(obj, k, ref)
+                    continue
+                setattr(obj, k, v)
+            except Exception as e:
+                log(f"[Обновление] Ошибка установки поля {k}: {e}")
+
+        while len(obj.Товары) > 0:
+            obj.Товары.Delete(0)
+
+        for row in items:
+            try:
+                new_row = obj.Товары.Add()
+                new_row.Номенклатура = self.bridge.get_ref("Номенклатура", row.get("Номенклатура"))
+                variant = row.get("ВариантИзготовления")
+                if variant and variant != "—":
+                    new_row.ВариантИзготовления = self.bridge.get_ref("ВариантыИзготовленияНоменклатуры", variant)
+                size_val = row.get("Размер", 0)
+                new_row.Размер = self.bridge.get_size_ref(size_val)
+                new_row.Количество = int(row.get("Количество", 1))
+                new_row.Вес = float(row.get("Вес", 0))
+                new_row.Примечание = row.get("Примечание", "")
+            except Exception as e:
+                log(f"[Обновление] Ошибка в строке заказа: {e}")
+
+        try:
+            obj.Write()
+            log(f"✔ Обновлён заказ №{number}")
+            return True
+        except Exception as e:
+            log(f"[Обновление] Ошибка при записи: {e}")
+            return False
+
+    def create_order(self, fields: dict, items: list) -> str:
+        doc = self.bridge.documents.ЗаказВПроизводство.CreateDocument()
+        catalog_fields_map = {
+            "Организация": "Организации",
+            "Контрагент": "Контрагенты",
+            "ДоговорКонтрагента": "ДоговорыКонтрагентов",
+            "Ответственный": "Пользователи",
+            "Склад": "Склады",
+        }
+
+        log("Создание заказа. Поля:")
+        for k, v in fields.items():
+            try:
+                log(f"  -> {k} = {v}")
+
+                if k == "ВидСтатусПродукции":
+                    reverse_map = {val: key for key, val in PRODUCTION_STATUS_MAP.items()}
+                    if v in reverse_map:
+                        v = reverse_map[v]
+
+                    ref = self.bridge.get_ref("ВидыСтатусыПродукции", v)
+                    log(f"[ref] {k}: {v} => {ref}")
+                    if ref:
+                        setattr(doc, k, ref)
+                        log(f"    Установлено: {k} (Ref: {ref})")
+                    else:
+                        log(f"    ❌ {k} '{v}' не найден.")
+                    continue
+
+                if k in catalog_fields_map:
+                    ref = self.bridge.get_ref(catalog_fields_map[k], v)
+                    log(f"[ref] {k}: {v} => {ref}")
+                    if ref:
+                        setattr(doc, k, ref)
+                        log(f"    Установлено: {k} (Ref: {ref})")
+                    else:
+                        log(f"    ❌ {k} '{v}' не найден.")
+                    continue
+
+                setattr(doc, k, v)
+            except Exception as e:
+                log(f"    ❌ Ошибка установки поля {k}: {e}")
+
+        log("Добавление строк заказа:")
+        for row in items:
+            try:
+                log(f"  -> строка: {row}")
+                new_row = doc.Товары.Add()
+                new_row.Номенклатура = self.bridge.get_ref("Номенклатура", row.get("Номенклатура"))
+
+                variant = row.get("ВариантИзготовления")
+                if variant and variant != "—":
+                    new_row.ВариантИзготовления = self.bridge.get_ref("ВариантыИзготовленияНоменклатуры", variant)
+
+                size_val = row.get("Размер", 0)
+                size_ref = self.bridge.get_size_ref(size_val)
+                if size_ref:
+                    new_row.Размер = size_ref
+                else:
+                    log(f"    ❌ Размер '{size_val}' не найден, пропущен")
+
+                new_row.Количество = int(row.get("Количество", 1))
+                new_row.Вес = float(row.get("Вес", 0))
+                log(f"    -> Примечание: {row.get('Примечание')}")
+                new_row.Примечание = row.get("Примечание", "")
+
+            except Exception as e:
+                log(f"    ❌ Ошибка в строке заказа: {e}")
+
+        try:
+            log("Проводим документ...")
+            doc.Write()
+            log(f"✅ Документ проведён. Номер: {doc.Number}")
+            return str(doc.Number)
+        except Exception as e:
+            log(f"❌ Ошибка при записи документа: {e}")
+            return f"Ошибка: {e}"
+
+    def list_orders(self) -> list[dict]:
+        result = []
+        orders = self.bridge.connection.Documents.ЗаказВПроизводство.Select()
+        while orders.Next():
+            doc = orders.GetObject()
+            rows = []
+            for row in doc.Товары:
+                rows.append({
+                    "nomenclature": safe_str(row.Номенклатура),
+                    "size": safe_str(row.Размер),
+                    "qty": row.Количество,
+                    "w": row.Вес,
+                    "variant": safe_str(row.ВариантИзготовления),
+                    "note": row.Примечание,
+                })
+            result.append({
+                "Ref": doc.Ref,
+                "num": doc.Номер,
+                "date": str(doc.Дата),
+                "org": safe_str(doc.Организация),
+                "contragent": safe_str(doc.Контрагент),
+                "contract": safe_str(doc.ДоговорКонтрагента),
+                "comment": safe_str(doc.Комментарий),
+                "prod_status": self.bridge.to_string(doc.ВидСтатусПродукции),
+                "posted": doc.Проведен,
+                "deleted": doc.ПометкаУдаления,
+                "qty": sum([r["qty"] for r in rows]),
+                "weight": sum([r["w"] for r in rows]),
+                "rows": rows,
+            })
+        return result
+
+    def get_order_lines(self, doc_number: str, date: str | None = None) -> list[dict]:
+        doc = self.bridge._find_document_by_number("ЗаказВПроизводство", doc_number, date)
+        if not doc:
+            log(f"❌ Заказ №{doc_number} не найден")
+            return []
+
+        rows = []
+        for r in doc.Товары:
+            rows.append({
+                "name": safe_str(r.Номенклатура),
+                "size": safe_str(getattr(r, "Размер", "")),
+                "insert": safe_str(getattr(r, "ХарактеристикаВставок", "")),
+                "assay": safe_str(getattr(r, "Проба", "")),
+                "color": safe_str(getattr(r, "ЦветМеталла", "")),
+                "method": safe_str(getattr(r, "ВариантИзготовления", "")),
+                "qty": getattr(r, "Количество", 0),
+                "weight": float(getattr(r, "Вес", 0)),
+                "article": safe_str(getattr(r.Номенклатура, "Артикул", "")),
+            })
+        return rows
+

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -10,5 +10,418 @@ class WaxBridge:
     def __init__(self, bridge: 'COM1CBridge'):
         self.bridge = bridge
 
+    # -------------------------------------------------------------
+    # Методы работы с заданиями и нарядами
+    # -------------------------------------------------------------
+
+    def _find_task_by_number(self, number: str):
+        doc_manager = getattr(self.bridge.connection.Documents, "ЗаданиеНаПроизводство", None)
+        if doc_manager is None:
+            log("❌ Документ 'ЗаданиеНаПроизводство' не найден")
+            return None
+        selection = doc_manager.Select()
+        while selection.Next():
+            obj = selection.GetObject()
+            if str(obj.Number).strip() == str(number).strip():
+                return obj
+        return None
+
     def post_task(self, number: str) -> bool:
-        return self.bridge.post_task(number)
+        obj = self._find_task_by_number(number)
+        if not obj:
+            log(f"[Проведение] ❌ Задание №{number} не найдено")
+            return False
+        try:
+            obj.Проведен = True
+            obj.Write()
+            log(f"[Проведение] ✅ Задание №{number} проведено")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при проведении задания №{number}: {e}")
+            return False
+
+    def undo_post_task(self, number: str) -> bool:
+        obj = self._find_task_by_number(number)
+        if not obj:
+            log(f"[Снятие проведения] ❌ Задание №{number} не найдено")
+            return False
+        try:
+            obj.Проведен = False
+            obj.Write()
+            log(f"[Снятие проведения] ✅ Задание №{number} отменено")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при снятии проведения задания №{number}: {e}")
+            return False
+
+    def mark_task_for_deletion(self, number: str) -> bool:
+        obj = self._find_task_by_number(number)
+        if not obj:
+            log(f"[Пометка удаления] ❌ Задание №{number} не найдено")
+            return False
+        try:
+            obj.DeletionMark = True
+            obj.Write()
+            log(f"[Пометка удаления] ✅ Задание №{number} помечено на удаление")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при пометке на удаление задания №{number}: {e}")
+            return False
+
+    def unmark_task_deletion(self, number: str) -> bool:
+        obj = self._find_task_by_number(number)
+        if not obj:
+            log(f"[Снятие пометки] ❌ Задание №{number} не найдено")
+            return False
+        try:
+            obj.DeletionMark = False
+            obj.Write()
+            log(f"[Снятие пометки] ✅ Задание №{number} восстановлено")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при снятии пометки задания №{number}: {e}")
+            return False
+
+    def delete_task(self, number: str) -> bool:
+        obj = self._find_task_by_number(number)
+        if not obj:
+            log(f"[Удаление] ❌ Задание №{number} не найдено")
+            return False
+        try:
+            if getattr(obj, "Проведен", False):
+                obj.Проведен = False
+                obj.Write()
+
+            obj.DeletionMark = True
+            obj.Write()
+            obj.Delete()
+            log(f"[Удаление] ✅ Задание №{number} удалено")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при удалении задания №{number}: {e}")
+            return False
+
+    def list_tasks(self) -> list[dict]:
+        result = []
+        doc_manager = getattr(self.bridge.connection.Documents, "ЗаданиеНаПроизводство", None)
+        if doc_manager is None:
+            return result
+        selection = doc_manager.Select()
+        while selection.Next():
+            doc = selection.GetObject()
+            result.append({
+                "ref": str(doc.Ref),
+                "num": str(doc.Number),
+                "date": str(doc.Date.strftime("%d.%m.%Y")),
+                "employee": self.bridge.safe(doc, "Ответственный"),
+                "tech_op": self.bridge.safe(doc, "ТехОперация"),
+                "section": self.bridge.safe(doc, "ПроизводственныйУчасток"),
+                "posted": getattr(doc, "Проведен", False),
+                "deleted": getattr(doc, "ПометкаУдаления", False),
+            })
+        return result
+
+    def get_task_lines(self, doc_num: str) -> list[dict]:
+        result = []
+        doc_manager = getattr(self.bridge.connection.Documents, "ЗаданиеНаПроизводство", None)
+        if not doc_manager:
+            return result
+
+        selection = doc_manager.Select()
+        while selection.Next():
+            doc = selection.GetObject()
+            if str(doc.Number) == str(doc_num):
+                for row in doc.Продукция:
+                    result.append({
+                        "nomen": self.bridge.safe(row, "Номенклатура"),
+                        "article": safe_str(getattr(row.Номенклатура, "Артикул", "")),
+                        "size": self.bridge.safe(row, "Размер"),
+                        "sample": self.bridge.safe(row, "Проба"),
+                        "color": self.bridge.safe(row, "ЦветМеталла"),
+                        "qty": row.Количество,
+                        "weight": row.Вес if hasattr(row, "Вес") else "",
+                    })
+                break
+        return result
+
+    def list_wax_jobs(self) -> list[dict]:
+        result = []
+        docs = self.bridge.connection.Documents.НарядВосковыеИзделия.Select()
+        while docs.Next():
+            obj = docs.GetObject()
+            rows = getattr(obj, "ТоварыВыдано", [])
+            rows = getattr(obj, "Выдано", [])
+            weight = 0.0
+            qty = 0
+            for r in rows:
+                weight += getattr(r, "Вес", 0)
+                qty += getattr(r, "Количество", 0)
+
+            result.append({
+                "Номер": str(obj.Номер),
+                "Дата": obj.Дата.strftime("%d.%m.%Y"),
+                "Сотрудник": safe_str(obj.Сотрудник.Description),
+                "Вес": weight,
+                "Кол-во": qty,
+                "Проведен": obj.Проведен,
+                "Закрыт": "✅" if getattr(obj, "Проведен", False) else "—",
+                "Сотрудник": safe_str(obj.Сотрудник),
+                "ТехОперация": safe_str(obj.ТехОперация),
+                "Комментарий": safe_str(obj.Комментарий),
+                "Склад": safe_str(obj.Склад),
+                "ПроизводственныйУчасток": safe_str(obj.ПроизводственныйУчасток),
+                "Организация": safe_str(obj.Организация),
+                "Задание": safe_str(getattr(obj, "ЗаданиеНаПроизводство", "")) or "—",
+                "Ответственный": safe_str(obj.Ответственный),
+                "Вес": round(weight, 2),
+                "Кол-во": qty,
+            })
+        return result
+
+    def find_wax_jobs_by_task(self, task_ref) -> list[str]:
+        found: list[str] = []
+        docs = self.bridge.connection.Documents.НарядВосковыеИзделия.Select()
+        while docs.Next():
+            obj = docs.GetObject()
+            if getattr(obj, "ЗаданиеНаПроизводство", None) == task_ref:
+                found.append(str(obj.Ref))
+        log(f"[find_wax_jobs_by_task] найдено {len(found)} нарядов")
+        return found
+
+    def close_wax_jobs(self, job_refs: list[str]) -> list[str]:
+        closed: list[str] = []
+        for ref in job_refs:
+            try:
+                doc = self.bridge.connection.GetObject(ref)
+                try:
+                    doc.ТоварыПринято.ЗаполнитьПоВыданному()
+                except Exception as exc:
+                    log(f"[close_wax_jobs] ⚠ Заполнение: {exc}")
+                try:
+                    doc.Закрыт = True
+                except Exception:
+                    pass
+                doc.Провести()
+                closed.append(str(doc.Номер))
+                log(f"[close_wax_jobs] ✅ {doc.Номер}")
+            except Exception as e:
+                log(f"[close_wax_jobs] ❌ {e}")
+        return closed
+
+    def get_wax_job_lines(self, doc_num: str) -> list[dict]:
+        result = []
+        doc_manager = getattr(self.bridge.connection.Documents, "НарядВосковыеИзделия", None)
+        if not doc_manager:
+            return result
+
+        selection = doc_manager.Select()
+        while selection.Next():
+            doc = selection.GetObject()
+            if str(doc.Number) == str(doc_num):
+                for row in doc.ТоварыВыдано:
+                    result.append({
+                        "norm": self.bridge.safe(row, "ВидНорматива"),
+                        "nomen": self.bridge.safe(row, "Номенклатура"),
+                        "size": self.bridge.safe(row, "Размер"),
+                        "sample": self.bridge.safe(row, "Проба"),
+                        "color": self.bridge.safe(row, "ЦветМеталла"),
+                        "qty": row.Количество,
+                        "weight": round(float(row.Вес), self.bridge.config.WEIGHT_DECIMALS) if hasattr(row, "Вес") else "",
+                    })
+                break
+        return result
+
+    def get_wax_job_rows(self, num: str) -> list[dict]:
+        doc = self.bridge._find_doc("НарядВосковыеИзделия", num)
+        rows = []
+        for r in doc.Выдано:
+            rows.append({
+                "Номенклатура": self.bridge.safe(r, "Номенклатура"),
+                "Размер": self.bridge.safe(r, "Размер"),
+                "Проба": self.bridge.safe(r, "Проба"),
+                "Цвет": self.bridge.safe(r, "ЦветМеталла"),
+                "Количество": r.Количество,
+                "Вес": round(float(r.Вес), self.bridge.config.WEIGHT_DECIMALS),
+                "Партия": self.bridge.safe(r, "Партия"),
+                "Номер ёлки": r.НомерЕлки if hasattr(r, "НомерЕлки") else "",
+                "Состав набора": r.СоставНабора if hasattr(r, "СоставНабора") else "",
+            })
+        return rows
+
+    def create_wax_job_from_task(self, task_number: str) -> str:
+        task = self._find_task_by_number(task_number)
+        if not task:
+            log(f"❌ Задание №{task_number} не найдено")
+            return ""
+
+        try:
+            doc = self.bridge.connection.Documents.НарядВосковыеИзделия.CreateDocument()
+        except Exception as e:
+            log(f"[1C] Не удалось создать НарядВосковыеИзделия: {e}")
+            return ""
+
+        try:
+            from datetime import datetime
+            doc.Date = datetime.now()
+            doc.ДокументОснование = task
+            doc.ТехОперация = getattr(task, "ТехОперация", None)
+            doc.ПроизводственныйУчасток = getattr(task, "ПроизводственныйУчасток", None)
+            doc.Ответственный = getattr(task, "РабочийЦентр", None)
+
+            order_ref = getattr(task, "ЗаказВПроизводство", None) or getattr(task, "ДокументОснование", None)
+            order_obj = None
+            if order_ref and hasattr(order_ref, "GetObject"):
+                try:
+                    order_obj = order_ref.GetObject()
+                    log("[create_wax_job_from_task] ✅ Получен заказ-основание")
+                except Exception as exc:
+                    log(f"[create_wax_job_from_task] ⚠ Ошибка получения заказа: {exc}")
+
+            if order_obj:
+                try:
+                    org = getattr(order_obj, "Организация", None)
+                    if org:
+                        doc.Организация = org if hasattr(org, "Ref") else org
+                        log(f"[create_wax_job_from_task] ✅ Установлена организация: {safe_str(org)}")
+                except Exception as e:
+                    log(f"[create_wax_job_from_task] ⚠ Не удалось установить организацию: {e}")
+
+                try:
+                    wh = getattr(order_obj, "Склад", None)
+                    if wh:
+                        doc.Склад = wh if hasattr(wh, "Ref") else wh
+                        log(f"[create_wax_job_from_task] ✅ Установлен склад: {safe_str(wh)}")
+                except Exception as e:
+                    log(f"[create_wax_job_from_task] ⚠ Не удалось установить склад: {e}")
+
+            for row in task.Продукция:
+                r = doc.ТоварыВыдано.Add()
+                r.Номенклатура = row.Номенклатура
+                r.Размер = row.Размер
+                r.Количество = row.Количество
+                r.ВариантИзготовления = row.ВариантИзготовления
+                r.Проба = row.Проба
+                r.ЦветМеталла = row.ЦветМеталла
+                r.Вес = row.Вес
+
+            doc.Write()
+            doc.Провести()
+            log(f"✅ Создан НарядВосковыеИзделия №{doc.Number}")
+            return str(doc.Number)
+        except Exception as e:
+            log(f"❌ Ошибка создания Наряда: {e}")
+            return ""
+
+    def create_wax_jobs_from_task(
+        self,
+        task_ref,
+        master_3d: str,
+        master_form: str,
+        warehouse: str | None = None,
+        norm_type: str = "Номенклатура",
+    ) -> list[str]:
+        mapping = {"3D печать": master_3d, "Пресс-форма": master_form}
+        result: list[str] = []
+
+        try:
+            if isinstance(task_ref, str):
+                task = self.bridge.connection.GetObject(task_ref)
+            elif hasattr(task_ref, "Продукция"):
+                task = task_ref
+            elif hasattr(task_ref, "GetObject"):
+                task = task_ref.GetObject()
+            else:
+                log("[create_wax_jobs_from_task] ❌ Неверный тип ссылки")
+                return []
+            task_ref_link = task.Ref
+        except Exception as exc:
+            log(f"[create_wax_jobs_from_task] ❌ Ошибка доступа к заданию: {exc}")
+            return []
+
+        org = getattr(task, "Организация", None)
+        wh = getattr(task, "Склад", None)
+        responsible = getattr(task, "Ответственный", None)
+
+        order_ref = getattr(task, "ЗаказВПроизводство", None) or getattr(task, "ДокументОснование", None)
+        if (org is None or wh is None) and order_ref and hasattr(order_ref, "GetObject"):
+            try:
+                order_obj = order_ref.GetObject()
+                org = org or getattr(order_obj, "Организация", None)
+                wh = wh or getattr(order_obj, "Склад", None)
+                responsible = responsible or getattr(order_obj, "Ответственный", None)
+            except Exception as e:
+                log(f"[create_wax_jobs_from_task] ⚠ Не удалось получить данные из заказа: {e}")
+
+        section = getattr(task, "ПроизводственныйУчасток", None)
+        if warehouse:
+            wh = self.bridge.get_ref_by_description("Склады", warehouse) or wh
+
+        rows_by_method = {"3D печать": [], "Пресс-форма": []}
+        for row in task.Продукция:
+            art = safe_str(getattr(row.Номенклатура, "Артикул", "")).lower()
+            method = "3D печать" if "д" in art or "d" in art else "Пресс-форма"
+            rows_by_method[method].append(row)
+
+        for method, rows in rows_by_method.items():
+            if not rows:
+                continue
+            try:
+                job = self.bridge.connection.Documents.НарядВосковыеИзделия.CreateDocument()
+
+                job.Дата = datetime.now()
+                job.ДокументОснование = task_ref_link
+                job.ЗаданиеНаПроизводство = task_ref_link
+                if org is not None:
+                    try:
+                        job.Организация = org
+                    except Exception as exc:
+                        log(f"[create_wax_jobs_from_task] ⚠ Не удалось установить организацию: {exc}")
+                if wh is not None:
+                    try:
+                        job.Склад = wh
+                    except Exception as exc:
+                        log(f"[create_wax_jobs_from_task] ⚠ Не удалось установить склад: {exc}")
+                if section:
+                    job.ПроизводственныйУчасток = section
+                if responsible:
+                    job.Ответственный = responsible
+                job.ТехОперация = self.bridge.get_ref("ТехОперации", method)
+                job.Сотрудник = self.bridge.get_ref("ФизическиеЛица", mapping.get(method, ""))
+                job.Комментарий = f"Создан автоматически для {method}"
+
+                for r in rows:
+                    row = job.ТоварыВыдано.Add()
+                    row.Номенклатура = r.Номенклатура
+                    row.Количество = r.Количество
+                    row.Размер = r.Размер
+                    row.Проба = r.Проба
+                    row.ЦветМеталла = r.ЦветМеталла
+                    if hasattr(r, "ХарактеристикаВставок"):
+                        row.ХарактеристикаВставок = r.ХарактеристикаВставок
+                    if hasattr(r, "Вес"):
+                        row.Вес = r.Вес
+
+                enum_norm = self.bridge.get_enum_by_description(
+                    "ВидыНормативовНоменклатуры", norm_type
+                )
+                if enum_norm:
+                    for row in job.ТоварыВыдано:
+                        row.ВидНорматива = enum_norm
+
+                for row in job.ТоварыВыдано:
+                    nomenclature = getattr(row, "Номенклатура", None)
+                    if nomenclature is not None:
+                        type_enum = self.bridge.get_object_property(nomenclature, "ТипНоменклатуры")
+                        enum = self.bridge.get_enum_by_description(
+                            "ВидыНормативовНоменклатуры",
+                            "Номенклатура" if safe_str(type_enum) == "Продукция" else "Комплектующее",
+                        )
+                        if enum:
+                            row.ВидНорматива = enum
+
+                job.Write()
+                result.append(str(job.Номер))
+                log(f"[create_wax_jobs_from_task] ✅ Создан наряд {method}: №{job.Номер}")
+            except Exception as exc:
+                log(f"[create_wax_jobs_from_task] ❌ Ошибка для {method}: {exc}")
+        return result


### PR DESCRIPTION
## Summary
- move order-related methods into `OrdersBridge`
- expand `WaxBridge` with task and job helpers

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d78e570832abd4b3d3988bec8c3