### PR TITLE
Improve wax job closing logic

### DIFF
--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -624,6 +624,7 @@ class WaxPage(QWidget):
                 table.insertRow(r)
                 chk = QTableWidgetItem()
                 chk.setCheckState(Qt.Checked)
+                chk.setData(Qt.UserRole, str(ref))
                 table.setItem(r, 0, chk)
                 values = [
                     r_data.get("nomen", ""),
@@ -851,11 +852,21 @@ class WaxPage(QWidget):
             ])
 
     def _on_close_jobs(self):
-        if not getattr(self, "close_job_refs", None):
+        tables = [self.tbl_close_3d, self.tbl_close_form]
+        job_refs: set[str] = set()
+        for tbl in tables:
+            for row in range(tbl.rowCount()):
+                item = tbl.item(row, 0)
+                if item and item.checkState() == Qt.Checked:
+                    ref = item.data(Qt.UserRole)
+                    if ref:
+                        job_refs.add(str(ref))
+
+        if not job_refs:
             QMessageBox.warning(self, "Ошибка", "Нет выбранных нарядов")
             return
 
-        result = config.BRIDGE.close_wax_jobs(self.close_job_refs)
+        result = config.BRIDGE.close_wax_jobs(list(job_refs))
         if result:
             QMessageBox.information(
                 self,


### PR DESCRIPTION
## Summary
- support selective wax job closing on WaxPage

## Testing
- `python -m py_compile pages/wax_page.py`


------
https://chatgpt.com/codex/tasks/task_e_684d9cfb64a4832abfb8c0e5fe484265