### PR TITLE
Improve task selection for closing wax jobs

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -776,7 +776,8 @@ class COM1CBridge:
         docs = self.connection.Documents.НарядВосковыеИзделия.Select()
         while docs.Next():
             obj = docs.GetObject()
-            if getattr(obj, "ЗаданиеНаПроизводство", None) == task_ref:
+            task_val = getattr(obj, "ЗаданиеНаПроизводство", None)
+            if task_val is not None and str(task_val) == str(task_ref):
                 found.append(str(obj.Ref))
         log(f"[find_wax_jobs_by_task] найдено {len(found)} нарядов")
         return found
@@ -1155,7 +1156,10 @@ class COM1CBridge:
 
     def get_object_from_ref(self, ref):
         try:
-            obj = ref.GetObject()
+            if hasattr(ref, "GetObject"):
+                obj = ref.GetObject()
+            else:
+                obj = self.connection.GetObject(ref)
             log(f"[get_object_from_ref] ✅ Получен объект из ссылки")
             return obj
         except Exception as e:

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -183,7 +183,8 @@ class WaxBridge:
         docs = self.bridge.connection.Documents.НарядВосковыеИзделия.Select()
         while docs.Next():
             obj = docs.GetObject()
-            if getattr(obj, "ЗаданиеНаПроизводство", None) == task_ref:
+            task_val = getattr(obj, "ЗаданиеНаПроизводство", None)
+            if task_val is not None and str(task_val) == str(task_ref):
                 found.append(str(obj.Ref))
         log(f"[find_wax_jobs_by_task] найдено {len(found)} нарядов")
         return found

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -520,7 +520,10 @@ class WaxPage(QWidget):
             cb(task_obj)
             self.tabs.setCurrentWidget(self.tab_jobs)
             if hasattr(self, "tabs_jobs"):
-                self.tabs_jobs.setCurrentIndex(0)
+                if cb == self.load_close_task_data:
+                    self.tabs_jobs.setCurrentIndex(1)
+                else:
+                    self.tabs_jobs.setCurrentIndex(0)
         else:
             self.tabs.setCurrentIndex(0)
             if hasattr(self, "tabs_tasks"):
@@ -624,6 +627,7 @@ class WaxPage(QWidget):
                 table.insertRow(r)
                 chk = QTableWidgetItem()
                 chk.setCheckState(Qt.Checked)
+                chk.setData(Qt.UserRole, str(ref))
                 table.setItem(r, 0, chk)
                 values = [
                     r_data.get("nomen", ""),
@@ -851,11 +855,21 @@ class WaxPage(QWidget):
             ])
 
     def _on_close_jobs(self):
-        if not getattr(self, "close_job_refs", None):
+        tables = [self.tbl_close_3d, self.tbl_close_form]
+        job_refs: set[str] = set()
+        for tbl in tables:
+            for row in range(tbl.rowCount()):
+                item = tbl.item(row, 0)
+                if item and item.checkState() == Qt.Checked:
+                    ref = item.data(Qt.UserRole)
+                    if ref:
+                        job_refs.add(str(ref))
+
+        if not job_refs:
             QMessageBox.warning(self, "Ошибка", "Нет выбранных нарядов")
             return
 
-        result = config.BRIDGE.close_wax_jobs(self.close_job_refs)
+        result = config.BRIDGE.close_wax_jobs(list(job_refs))
         if result:
             QMessageBox.information(
                 self,


### PR DESCRIPTION
## Summary
- ensure wax jobs are searched using string comparison for task ref
- switch to close tab after selecting task when appropriate
- support retrieving objects from string refs

## Testing
- `python -m py_compile pages/wax_page.py core/com_bridge.py core/wax_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_684d9cfb64a4832abfb8c0e5fe484265