### PR TITLE
Fix wax job reference retrieval

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -770,24 +770,24 @@ class COM1CBridge:
             })
         return result
 
-    def find_wax_jobs_by_task(self, task_ref) -> list[str]:
+    def find_wax_jobs_by_task(self, task_ref) -> list:
         """Возвращает ссылки нарядов, созданных по заданию."""
-        found: list[str] = []
+        found: list = []
         docs = self.connection.Documents.НарядВосковыеИзделия.Select()
         while docs.Next():
             obj = docs.GetObject()
             task_val = getattr(obj, "ЗаданиеНаПроизводство", None)
             if task_val is not None and str(task_val) == str(task_ref):
-                found.append(str(obj.Ref))
+                found.append(obj.Ref)
         log(f"[find_wax_jobs_by_task] найдено {len(found)} нарядов")
         return found
 
-    def close_wax_jobs(self, job_refs: list[str]) -> list[str]:
+    def close_wax_jobs(self, job_refs: list) -> list[str]:
         """Закрывает наряды по списку ссылок."""
         closed: list[str] = []
         for ref in job_refs:
             try:
-                doc = self.connection.GetObject(ref)
+                doc = self.get_object_from_ref(ref)
                 try:
                     doc.ТоварыПринято.ЗаполнитьПоВыданному()
                 except Exception as exc:

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -178,22 +178,22 @@ class WaxBridge:
             })
         return result
 
-    def find_wax_jobs_by_task(self, task_ref) -> list[str]:
-        found: list[str] = []
+    def find_wax_jobs_by_task(self, task_ref) -> list:
+        found: list = []
         docs = self.bridge.connection.Documents.НарядВосковыеИзделия.Select()
         while docs.Next():
             obj = docs.GetObject()
             task_val = getattr(obj, "ЗаданиеНаПроизводство", None)
             if task_val is not None and str(task_val) == str(task_ref):
-                found.append(str(obj.Ref))
+                found.append(obj.Ref)
         log(f"[find_wax_jobs_by_task] найдено {len(found)} нарядов")
         return found
 
-    def close_wax_jobs(self, job_refs: list[str]) -> list[str]:
+    def close_wax_jobs(self, job_refs: list) -> list[str]:
         closed: list[str] = []
         for ref in job_refs:
             try:
-                doc = self.bridge.connection.GetObject(ref)
+                doc = self.bridge.get_object_from_ref(ref)
                 try:
                     doc.ТоварыПринято.ЗаполнитьПоВыданному()
                 except Exception as exc:


### PR DESCRIPTION
## Summary
- fix find_wax_jobs_by_task to return COM references instead of strings
- load wax jobs for closing using bridge helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684da338162c832a8684e0bac25c46b3