### PR TITLE
Fix wax job lines retrieval by reference

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1075,6 +1075,25 @@ class COM1CBridge:
                 break
         return result
 
+    def get_wax_job_lines_by_ref(self, ref):
+        """Возвращает табличную часть 'ТоварыВыдано' по ссылке на наряд"""
+        try:
+            doc = self.connection.GetObject(ref)
+            result = []
+            for row in doc.ТоварыВыдано:
+                result.append({
+                    "nomen": self.safe(row, "Номенклатура"),
+                    "size": self.safe(row, "Размер"),
+                    "sample": self.safe(row, "Проба"),
+                    "color": self.safe(row, "ЦветМеталла"),
+                    "qty": row.Количество,
+                    "weight": round(float(row.Вес), config.WEIGHT_DECIMALS) if hasattr(row, "Вес") else "",
+                })
+            return result
+        except Exception as e:
+            log(f"[get_wax_job_lines_by_ref] ❌ Ошибка: {e}")
+            return []
+
     # ------------------------------------------------------------------
     def create_wax_job_from_task(self, task_number: str) -> str:
         """Создаёт 'НарядВосковыеИзделия' на основании задания."""

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -621,7 +621,7 @@ class WaxPage(QWidget):
             self.close_job_refs.append(str(ref))
             method = str(getattr(job_obj, "ТехОперация", "")).lower()
             is_3d = "3" in method or "д" in method
-            rows = config.BRIDGE.get_wax_job_lines(str(job_obj.Номер))
+            rows = config.BRIDGE.get_wax_job_lines_by_ref(job_obj.Ref)
             table = self.tbl_close_3d if is_3d else self.tbl_close_form
             for r_data in rows:
                 r = table.rowCount()


### PR DESCRIPTION
## Summary
- fetch wax job lines by `Ref` instead of document number when closing jobs
- add helper `get_wax_job_lines_by_ref` in `COM1CBridge`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da891e64c832aa843edffa047ed49