### PR TITLE
Fix wax job search by production task

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -784,13 +784,14 @@ class COM1CBridge:
         if hasattr(docs, "Count"):
             log(f"[find_wax_jobs_by_task] всего найдено {docs.Count()} нарядов")
 
+        # Не получаем объект целиком, сравниваем ссылки прямо в выборке
         while docs.Next():
-            job = docs.GetObject()
-            if not job or not hasattr(job, "ЗаданиеНаПроизводство"):
-                continue
             try:
-                if str(job.ЗаданиеНаПроизводство) == task_ref:
-                    result.append(job.Ref)
+                job_task_ref = getattr(docs, "ЗаданиеНаПроизводство", None)
+                if job_task_ref is None:
+                    continue
+                if str(job_task_ref) == task_ref:
+                    result.append(docs.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")
 

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -191,13 +191,14 @@ class WaxBridge:
         if hasattr(docs, "Count"):
             log(f"[find_wax_jobs_by_task] всего найдено {docs.Count()} нарядов")
 
+        # Не получаем объект, сравниваем ссылки в выборке
         while docs.Next():
-            job = docs.GetObject()
-            if not job or not hasattr(job, "ЗаданиеНаПроизводство"):
-                continue
             try:
-                if str(job.ЗаданиеНаПроизводство) == task_ref:
-                    result.append(job.Ref)
+                job_task_ref = getattr(docs, "ЗаданиеНаПроизводство", None)
+                if job_task_ref is None:
+                    continue
+                if str(job_task_ref) == task_ref:
+                    result.append(docs.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")
 


### PR DESCRIPTION
## Summary
- avoid loading whole documents in `find_wax_jobs_by_task`
- compare task references directly when filtering jobs

## Testing
- `pytest` *(fails: no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8806f80832aac7b0167cac8b087