### PR TITLE
Fix wax job filtering by production task

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -614,6 +614,23 @@ class COM1CBridge:
 
         log(f"[get_doc_ref] ❌ Документ {doc_name} №{number} не найден")
         return None
+
+    def list_documents(self, doc_name: str) -> list:
+        """Возвращает список объектов документов указанного типа."""
+        result: list = []
+        docs = getattr(self.connection.Documents, doc_name, None)
+        if docs is None:
+            log(f"[list_documents] Документ '{doc_name}' не найден")
+            return result
+
+        selection = docs.Select()
+        while selection.Next():
+            try:
+                obj = selection.GetObject()
+                result.append(obj)
+            except Exception as e:
+                log(f"[list_documents] ❌ Ошибка: {e}")
+        return result
     # ------------------------------------------------------------------
     def list_orders(self):
         result = []
@@ -774,23 +791,15 @@ class COM1CBridge:
         """Возвращает ссылки нарядов для выбранного задания."""
         result: list = []
 
-        try:
-            task_ref = getattr(task_ref, "Ref", task_ref)
-        except Exception:
-            pass
         task_ref = str(task_ref)
 
-        docs = self.connection.Documents.НарядВосковыеИзделия.Select()
-        if hasattr(docs, "Count"):
-            log(f"[find_wax_jobs_by_task] всего найдено {docs.Count()} нарядов")
-
-        while docs.Next():
-            job = docs.GetObject()
-            if not job or not hasattr(job, "ЗаданиеНаПроизводство"):
-                continue
+        jobs = self.list_documents("НарядВосковыеИзделия")
+        for job in jobs:
             try:
-                if str(job.ЗаданиеНаПроизводство) == task_ref:
-                    result.append(job.Ref)
+                if hasattr(job, "ЗаданиеНаПроизводство"):
+                    job_task_ref = str(job.ЗаданиеНаПроизводство)
+                    if job_task_ref == str(task_ref):
+                        result.append(job.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")
 

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -182,22 +182,15 @@ class WaxBridge:
         """Возвращает наряды, связанные с указанным заданием."""
         result: list = []
 
-        if hasattr(task_ref, "Ref"):
-            task_ref = task_ref.Ref
-
         task_ref = str(task_ref)
 
-        docs = self.bridge.connection.Documents.НарядВосковыеИзделия.Select()
-        if hasattr(docs, "Count"):
-            log(f"[find_wax_jobs_by_task] всего найдено {docs.Count()} нарядов")
-
-        while docs.Next():
-            job = docs.GetObject()
-            if not job or not hasattr(job, "ЗаданиеНаПроизводство"):
-                continue
+        jobs = self.bridge.list_documents("НарядВосковыеИзделия")
+        for job in jobs:
             try:
-                if str(job.ЗаданиеНаПроизводство) == task_ref:
-                    result.append(job.Ref)
+                if hasattr(job, "ЗаданиеНаПроизводство"):
+                    job_task_ref = str(job.ЗаданиеНаПроизводство)
+                    if job_task_ref == task_ref:
+                        result.append(job.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")
 


### PR DESCRIPTION
## Summary
- add generic `list_documents` helper
- refactor `find_wax_jobs_by_task` to filter via `list_documents`

## Testing
- `pytest -q`
- `python -m py_compile core/com_bridge.py core/wax_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_684dc8806f80832aac7b0167cac8b087