### PR TITLE
Fix wax job search by task

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -788,20 +788,21 @@ class COM1CBridge:
         return result
 
     def find_wax_jobs_by_task(self, task_ref) -> list:
-        """Возвращает ссылки на наряды, у которых задание соответствует task_ref."""
+        """Возвращает ссылки на наряды, у которых задание соответствует ``task_ref``."""
         result: list = []
 
+        task_str = self.to_string(task_ref)
         jobs = self.list_documents("НарядВосковыеИзделия")
         for job in jobs:
             try:
                 if hasattr(job, "ЗаданиеНаПроизводство"):
-                    job_task_ref = str(job.ЗаданиеНаПроизводство)
-                    if job_task_ref == str(task_ref):
+                    job_task_ref = self.to_string(job.ЗаданиеНаПроизводство)
+                    if job_task_ref == task_str:
                         result.append(job.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")
 
-        log(f"[find_wax_jobs_by_task] найдено {len(result)} нарядов для задания {task_ref}")
+        log(f"[find_wax_jobs_by_task] найдено {len(result)} нарядов для задания {task_str}")
         return result
 
     def close_wax_jobs(self, job_refs: list) -> list[str]:

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -182,13 +182,13 @@ class WaxBridge:
         """Возвращает наряды, связанные с указанным заданием."""
         result: list = []
 
-        task_ref_str = str(task_ref)
+        task_ref_str = self.bridge.to_string(task_ref)
         jobs = self.bridge.list_documents("НарядВосковыеИзделия")
 
         for job in jobs:
             try:
                 job_task_ref = getattr(job, "ЗаданиеНаПроизводство", None)
-                if job_task_ref and str(job_task_ref) == task_ref_str:
+                if job_task_ref and self.bridge.to_string(job_task_ref) == task_ref_str:
                     result.append(job.Ref)
             except Exception as e:
                 log(f"[find_wax_jobs_by_task] ❌ Ошибка: {e}")


### PR DESCRIPTION
## Summary
- fix comparison of task references when searching wax jobs by task

## Testing
- `pre-commit` *(fails: no pre-commit config)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd597b90832a82abbf1d7042ba34