### PR TITLE
Fix order closing when document not found

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -811,6 +811,9 @@ class COM1CBridge:
         for ref in job_refs:
             try:
                 doc = self.get_object_from_ref(ref)
+                if not doc:
+                    log("[close_wax_jobs] ❌ Не удалось получить документ по ссылке")
+                    continue
                 try:
                     doc.ТоварыПринято.ЗаполнитьПоВыданному()
                 except Exception as exc:

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -201,6 +201,9 @@ class WaxBridge:
         for ref in job_refs:
             try:
                 doc = self.bridge.get_object_from_ref(ref)
+                if not doc:
+                    log("[close_wax_jobs] ❌ Не удалось получить документ по ссылке")
+                    continue
                 try:
                     doc.ТоварыПринято.ЗаполнитьПоВыданному()
                 except Exception as exc:


### PR DESCRIPTION
## Summary
- handle missing documents in `close_wax_jobs`

## Testing
- `pytest -q`
- `python -m py_compile core/com_bridge.py core/wax_bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_684ebea74040832ab558949a2bb1eaae