### PR TITLE
Fix closing wax jobs and enable job actions

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -773,6 +773,7 @@ class COM1CBridge:
                 "Вес": weight,
                 "Кол-во": qty,
                 "Проведен": obj.Проведен,
+                "ПометкаУдаления": getattr(obj, "ПометкаУдаления", False),
                 "Закрыт": "✅" if getattr(obj, "Проведен", False) else "—",
                 "Сотрудник": safe_str(obj.Сотрудник),
                 "ТехОперация": safe_str(obj.ТехОперация),
@@ -1445,6 +1446,97 @@ class COM1CBridge:
             return True
         except Exception as e:
             log(f"❌ Ошибка при удалении задания №{number}: {e}")
+            return False
+
+    # -------------------------------------------------------------
+    # Методы для работы с нарядами
+    # -------------------------------------------------------------
+
+    def _find_wax_job_by_number(self, number: str):
+        doc_manager = getattr(self.connection.Documents, "НарядВосковыеИзделия", None)
+        if doc_manager is None:
+            log("❌ Документ 'НарядВосковыеИзделия' не найден")
+            return None
+        selection = doc_manager.Select()
+        while selection.Next():
+            obj = selection.GetObject()
+            if str(obj.Number).strip() == str(number).strip():
+                return obj
+        return None
+
+    def post_wax_job(self, number: str) -> bool:
+        obj = self._find_wax_job_by_number(number)
+        if not obj:
+            log(f"[Проведение] ❌ Наряд №{number} не найден")
+            return False
+        try:
+            obj.Проведен = True
+            obj.Write()
+            log(f"[Проведение] ✅ Наряд №{number} проведён")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при проведении наряда №{number}: {e}")
+            return False
+
+    def undo_post_wax_job(self, number: str) -> bool:
+        obj = self._find_wax_job_by_number(number)
+        if not obj:
+            log(f"[Снятие проведения] ❌ Наряд №{number} не найден")
+            return False
+        try:
+            obj.Проведен = False
+            obj.Write()
+            log(f"[Снятие проведения] ✅ Наряд №{number} отменён")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при отмене проведения наряда №{number}: {e}")
+            return False
+
+    def mark_wax_job_for_deletion(self, number: str) -> bool:
+        obj = self._find_wax_job_by_number(number)
+        if not obj:
+            log(f"[Пометка удаления] ❌ Наряд №{number} не найден")
+            return False
+        try:
+            obj.DeletionMark = True
+            obj.Write()
+            log(f"[Пометка удаления] ✅ Наряд №{number} помечен на удаление")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при пометке наряда №{number}: {e}")
+            return False
+
+    def unmark_wax_job_deletion(self, number: str) -> bool:
+        obj = self._find_wax_job_by_number(number)
+        if not obj:
+            log(f"[Снятие пометки] ❌ Наряд №{number} не найден")
+            return False
+        try:
+            obj.DeletionMark = False
+            obj.Write()
+            log(f"[Снятие пометки] ✅ Наряд №{number} восстановлен")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при снятии пометки наряда №{number}: {e}")
+            return False
+
+    def delete_wax_job(self, number: str) -> bool:
+        obj = self._find_wax_job_by_number(number)
+        if not obj:
+            log(f"[Удаление] ❌ Наряд №{number} не найден")
+            return False
+        try:
+            if getattr(obj, "Проведен", False):
+                obj.Проведен = False
+                obj.Write()
+
+            obj.DeletionMark = True
+            obj.Write()
+            obj.Delete()
+            log(f"[Удаление] ✅ Наряд №{number} удалён")
+            return True
+        except Exception as e:
+            log(f"❌ Ошибка при удалении наряда №{number}: {e}")
             return False
             
             


### PR DESCRIPTION
## Summary
- keep references when closing wax jobs
- color job list rows and add checkboxes
- add actions for posting/unposting and deletion of wax jobs
- expose new job management methods in COM bridge and Wax bridge

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ec1bfdb38832aa9985b20afc083b6