### PR TITLE
Add Windows-only check before starting GUI

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@
 ##############################################################################
 
 import sys
+import os
 from pathlib import Path
 
 # Добавляем пути для импорта
@@ -125,6 +126,9 @@ class Main(QMainWindow):
 
 # Точка входа
 if __name__ == "__main__":
+    if os.name != "nt":
+        print("Только для Windows")
+        sys.exit()
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
     app = QApplication(sys.argv); app.setStyle("Fusion")
 


### PR DESCRIPTION
## Summary
- import `os` and exit for non-Windows systems with a Russian message

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850443de96c832a87f018d37a1a5fc8