### PR TITLE
Clean up employee login loader

### DIFF
--- a/config.py
+++ b/config.py
@@ -107,19 +107,7 @@ def load_employee_logins() -> list[str]:
         logger.error("Не удалось загрузить логины из XML: %s", exc)
         return fallback
 
-
-    """Загружает логины сотрудников из дампа конфигурации."""
-    try:
-        users = config_parser.get_catalog_items("Пользователи")
-        return users or ["Администратор"]
-    except Exception as exc:  # безопасность на случай проблем парсинга
-        logger.error("Не удалось загрузить логины сотрудников: %s", exc)
-        return ["Администратор"]
-
-
 EMPLOYEE_LOGINS = load_employee_logins()
-
-
 # ------------------------------------------------------------------
 # Список сотрудников из справочника "ФизическиеЛица"
 def load_employees(limit: int = 200) -> list[str]:


### PR DESCRIPTION
## Summary
- remove duplicate docstring and fallback logic in `load_employee_logins`
- ensure the function returns the fallback when COM and XML loading fail

## Testing
- `python3 -m py_compile config.py`


------
https://chatgpt.com/codex/tasks/task_e_68504429bd5c832a851bfc98df91549e