### PR TITLE
Fix wax job creation and closing

### DIFF
--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -351,6 +351,13 @@ class WaxBridge:
                     doc.Закрыт = True
                 except Exception:
                     pass
+
+                try:
+                    doc.Write()
+                    log(f"[close_wax_jobs] ✅ Записан документ {doc.Номер}")
+                except Exception as exc:
+                    log(f"[close_wax_jobs] ⚠ Ошибка при записи: {exc}")
+
                 doc.Провести()
                 closed.append(str(doc.Номер))
                 log(f"[close_wax_jobs] ✅ {doc.Номер}")
@@ -427,20 +434,26 @@ class WaxBridge:
                 except Exception as exc:
                     log(f"[create_wax_job_from_task] ⚠ Ошибка получения заказа: {exc}")
 
-            if order_obj:
+            org = getattr(task, "Организация", None)
+            wh = getattr(task, "Склад", None)
+            if (org is None or wh is None) and order_obj:
                 try:
-                    org = getattr(order_obj, "Организация", None)
-                    if org:
-                        doc.Организация = org if hasattr(org, "Ref") else org
-                        log(f"[create_wax_job_from_task] ✅ Установлена организация: {safe_str(org)}")
+                    org = org or getattr(order_obj, "Организация", None)
+                    wh = wh or getattr(order_obj, "Склад", None)
+                except Exception as exc:
+                    log(f"[create_wax_job_from_task] ⚠ Ошибка получения данных заказа: {exc}")
+
+            if org is not None:
+                try:
+                    doc.Организация = org if hasattr(org, "Ref") else org
+                    log(f"[create_wax_job_from_task] ✅ Установлена организация: {safe_str(org)}")
                 except Exception as e:
                     log(f"[create_wax_job_from_task] ⚠ Не удалось установить организацию: {e}")
 
+            if wh is not None:
                 try:
-                    wh = getattr(order_obj, "Склад", None)
-                    if wh:
-                        doc.Склад = wh if hasattr(wh, "Ref") else wh
-                        log(f"[create_wax_job_from_task] ✅ Установлен склад: {safe_str(wh)}")
+                    doc.Склад = wh if hasattr(wh, "Ref") else wh
+                    log(f"[create_wax_job_from_task] ✅ Установлен склад: {safe_str(wh)}")
                 except Exception as e:
                     log(f"[create_wax_job_from_task] ⚠ Не удалось установить склад: {e}")
 
@@ -488,14 +501,20 @@ class WaxBridge:
             log(f"[create_wax_jobs_from_task] ❌ Ошибка доступа к заданию: {exc}")
             return []
 
+        order_ref = getattr(task, "ЗаказВПроизводство", None) or getattr(task, "ДокументОснование", None)
+        order_obj = None
+        if order_ref and hasattr(order_ref, "GetObject"):
+            try:
+                order_obj = order_ref.GetObject()
+                log("[create_wax_jobs_from_task] ✅ Получен заказ-основание")
+            except Exception as exc:
+                log(f"[create_wax_jobs_from_task] ⚠ Ошибка получения заказа: {exc}")
+
         org = getattr(task, "Организация", None)
         wh = getattr(task, "Склад", None)
         responsible = getattr(task, "Ответственный", None)
-
-        order_ref = getattr(task, "ЗаказВПроизводство", None) or getattr(task, "ДокументОснование", None)
-        if (org is None or wh is None) and order_ref and hasattr(order_ref, "GetObject"):
+        if (org is None or wh is None) and order_obj:
             try:
-                order_obj = order_ref.GetObject()
                 org = org or getattr(order_obj, "Организация", None)
                 wh = wh or getattr(order_obj, "Склад", None)
                 responsible = responsible or getattr(order_obj, "Ответственный", None)


### PR DESCRIPTION
## Summary
- write wax documents before conducting
- restore fallback to fill `Организация` and `Склад` from order or task

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685052298158832a95cd3f4f5c852113