### PR TITLE
Fix COM enumerator usage in document search

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1346,7 +1346,7 @@ class COM1CBridge:
         try:
             docs = getattr(self.connection.Documents, doc_type)
             selection = docs.Select()
-            while not selection.Eof():
+            while not selection.Eof:
                 doc_ref = selection.Ref
                 doc_obj = doc_ref.GetObject()
                 if hasattr(doc_obj, attr_name) and getattr(doc_obj, attr_name) == value:


### PR DESCRIPTION
## Summary
- search COM enumerators via `.Eof` attribute instead of calling it as a function

## Testing
- `python -m py_compile core/com_bridge.py`
- `python -m py_compile core/wax_bridge.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850736abf94832aaaab7f2f036fb1c3