### PR TITLE
Fix posting of wax jobs

### DIFF
--- a/core/com_bridge.py
+++ b/core/com_bridge.py
@@ -1083,8 +1083,8 @@ class COM1CBridge:
                 r.ЦветМеталла = row.ЦветМеталла
                 r.Вес = row.Вес
 
+            doc.Проведен = True
             doc.Write()
-            doc.Провести()
             log(f"✅ Создан НарядВосковыеИзделия №{doc.Number}")
             return str(doc.Number)
         except Exception as e:
@@ -1235,6 +1235,7 @@ class COM1CBridge:
                         row.ВидНорматива = enum_norm
 
 
+                job.Проведен = True
                 job.Write()
                 result.append(str(job.Номер))
                 log(f"[create_wax_jobs_from_task] ✅ Создан наряд {method}: №{job.Номер}")

--- a/core/wax_bridge.py
+++ b/core/wax_bridge.py
@@ -326,8 +326,8 @@ class WaxBridge:
                 except Exception:
                     pass
 
+                doc.Проведен = True
                 doc.Write()
-                doc.Провести()
                 closed.append(str(doc.Номер))
                 log(f"[close_wax_jobs] ✅ {doc.Номер}")
             except Exception as e:
@@ -430,8 +430,8 @@ class WaxBridge:
                 r.ЦветМеталла = row.ЦветМеталла
                 r.Вес = row.Вес
 
+            doc.Проведен = True
             doc.Write()
-            doc.Провести()
             log(f"✅ Создан НарядВосковыеИзделия №{doc.Number}")
             return str(doc.Number)
         except Exception as e:
@@ -579,6 +579,7 @@ class WaxBridge:
                         if enum:
                             row.ВидНорматива = enum
 
+                job.Проведен = True
                 job.Write()
                 result.append(str(job.Номер))
                 log(f"[create_wax_jobs_from_task] ✅ Создан наряд {method}: №{job.Номер}")


### PR DESCRIPTION
## Summary
- avoid using nonexistent `Провести()` method
- finalize wax jobs by setting `Проведен` flag and calling `Write()`
- post automatically created wax jobs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685082d91438832a8239077827e3853a