### PR TITLE
Добавлена вкладка сборки ёлок

### DIFF
--- a/logic/state.py
+++ b/logic/state.py
@@ -2,3 +2,6 @@
 
 ORDERS_POOL = []
 WAX_JOBS_POOL = []
+
+# Очередь нарядов для сборки ёлок
+ASSEMBLY_POOL: list[dict] = []


### PR DESCRIPTION
## Summary
- add assembly queue state
- implement new "Сборка ёлок" tab on wax page
- support moving closed jobs to the assembly tab and forming trees

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524318e714832a85e6202cf8b93081