### PR TITLE
Fix indentation in wax page

### DIFF
--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -506,9 +506,6 @@ class WaxPage(QWidget):
 
         log(f"[UI] Отправка нарядов в сборку: {', '.join(jobs)}")
 
-            QMessageBox.warning(self, "Ошибка", "Выберите наряды")
-            return
-
         added = False
         for num in jobs:
             item_obj = None


### PR DESCRIPTION
## Summary
- fix indentation error in `WaxPage._send_job_to_work`

## Testing
- `python -m py_compile pages/wax_page.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa00829f0832ab81d559a617f9c3b