### PR TITLE
Добавлена сборка ёлок

### DIFF
--- a/logic/production_docs.py
+++ b/logic/production_docs.py
@@ -168,3 +168,32 @@ def log_event(job_code: str, stage: str, user: str | None = None, extra: Dict[st
     if extra:
         rec.update(extra)
     job["signed_log"].append(rec)
+
+
+def form_wax_trees(jobs: list[dict]) -> list[dict]:
+    """Группирует наряды в ёлки по металлу, пробе и цвету."""
+    from logic.state import TREES_POOL
+    grouped: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
+    for j in jobs:
+        key = (j.get("metal"), j.get("hallmark"), j.get("color"))
+        grouped[key].append(j)
+
+    trees = []
+    for (metal, hallmark, color), rows in grouped.items():
+        code = f"TR-{uuid4().hex[:6].upper()}"
+        qty = sum(r.get("qty", 0) for r in rows)
+        weight = round(sum(r.get("weight", 0) for r in rows), config.WEIGHT_DECIMALS)
+        tree = dict(
+            tree_code=code,
+            metal=metal,
+            hallmark=hallmark,
+            color=color,
+            qty=qty,
+            weight=weight,
+            jobs=[r.get("wax_job") for r in rows],
+        )
+        trees.append(tree)
+        TREES_POOL.append(tree)
+
+    return trees
+

--- a/logic/state.py
+++ b/logic/state.py
@@ -5,3 +5,6 @@ WAX_JOBS_POOL = []
 
 # Очередь нарядов для сборки ёлок
 ASSEMBLY_POOL: list[dict] = []
+
+# Сформированные ёлки после сборки
+TREES_POOL: list[dict] = []

--- a/pages/wax_page.py
+++ b/pages/wax_page.py
@@ -529,8 +529,6 @@ class WaxPage(QWidget):
             return
         if hasattr(self, "tabs_jobs"):
             self.tabs_jobs.setCurrentWidget(self.tab_tree)
-            # сразу формируем ёлки без выхода на список нарядов
-            self._form_trees(return_to_jobs=False)
     def _send_task_to_work(self):
         """Переносит выбранное задание на вкладку создания нарядов."""
         item = self.tree_tasks.currentItem()
@@ -1022,8 +1020,9 @@ class WaxPage(QWidget):
                 QTreeWidgetItem(root, [j["wax_job"], str(j.get("qty", 0)), f"{j.get('weight', 0):.{config.WEIGHT_DECIMALS}f}"])
 
     def _clear_assembly_pool(self):
-        from logic.state import ASSEMBLY_POOL
+        from logic.state import ASSEMBLY_POOL, TREES_POOL
         ASSEMBLY_POOL.clear()
+        TREES_POOL.clear()
         self._fill_assembly_tree()
 
     def _form_trees(self, return_to_jobs: bool = True):
@@ -1035,15 +1034,23 @@ class WaxPage(QWidget):
         if not ASSEMBLY_POOL:
             QMessageBox.information(self, "Сборка", "Нет нарядов для сборки")
             return
-        grouped = defaultdict(list)
-        for j in ASSEMBLY_POOL:
-            key = (j.get("metal"), j.get("hallmark"), j.get("color"))
-            grouped[key].append(j)
-        count = len(grouped)
+        from logic import production_docs
+
+        trees = production_docs.form_wax_trees(ASSEMBLY_POOL)
         ASSEMBLY_POOL.clear()
         self._fill_assembly_tree()
+
+        count = len(trees)
         log(f"[UI] Сформировано {count} ёлок")
-        QMessageBox.information(self, "Сборка ёлок", f"Сформировано {count} ёлок")
+        if count:
+            tree_codes = ", ".join(t["tree_code"] for t in trees)
+            QMessageBox.information(
+                self,
+                "Сборка ёлок",
+                f"Сформировано {count} ёлок: {tree_codes}",
+            )
+        else:
+            QMessageBox.information(self, "Сборка ёлок", "Ёлки не сформированы")
         if return_to_jobs and hasattr(self, "tabs_jobs"):
             # после формирования возвращаемся к выбору нарядов
             self.tabs_jobs.setCurrentIndex(2)


### PR DESCRIPTION
## Summary
- store assembled trees in `TREES_POOL`
- implement helper `form_wax_trees` to group jobs by металл/проба/цвет
- update wax page UI to use new helper and display созданные ёлки
- disable automatic tree formation when sending jobs to assembly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa3a045dc832a8a6fb2ab14d14382